### PR TITLE
Update __array_namespace__ to accept api_version.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Changelog
 
 - ndonnx now exports type annotations.
 
+**Bug fixes**
+
+- ``__array_namespace__`` now accepts the optional ``api_version`` argument to specify the version of the Array API to use.
+
 0.4.0 (2024-05-16)
 ------------------
 

--- a/ndonnx/_array.py
+++ b/ndonnx/_array.py
@@ -333,7 +333,7 @@ class Array:
         if api_version is None:
             api_version = "2023.12"
 
-        if api_version == "2022.12":
+        if api_version == "2023.12":
             return ndx
         else:
             raise ValueError(f"Unsupported API version {api_version}")

--- a/ndonnx/_array.py
+++ b/ndonnx/_array.py
@@ -329,8 +329,14 @@ class Array:
         return self._core().var
 
     @staticmethod
-    def __array_namespace__():
-        return ndx
+    def __array_namespace__(*, api_version: str | None = None):
+        if api_version is None:
+            api_version = "2023.12"
+
+        if api_version == "2022.12":
+            return ndx
+        else:
+            raise ValueError(f"Unsupported API version {api_version}")
 
     def __float__(self) -> float:
         eager_value = self.to_numpy()


### PR DESCRIPTION
Please note that while the version we support is 2023.12, we still have some missing functionality: https://github.com/Quantco/ndonnx/issues/6.