### PR TITLE
Fix public export promote_nullable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@
 Changelog
 =========
 
+0.5.1 (unreleased)
+------------------
+
+**Bug fixes**
+
+- Public export of :func:`ndonnx.promote_nullable` is now working.
+
 0.5.0 (2024-07-01)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,12 @@
 Changelog
 =========
 
-0.5.1 (unreleased)
+0.6.0 (unreleased)
 ------------------
 
-**Bug fixes**
+**Other changes**
 
-- Public export of :func:`ndonnx.promote_nullable` is now working.
-
+- :func:`ndonnx.promote_nullable` is now publicly exported
 0.5.0 (2024-07-01)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@
 Changelog
 =========
 
-0.6.0 (unreleased)
+0.6.0 (2024-07-11)
 ------------------
 
 **Other changes**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changelog
 **Other changes**
 
 - :func:`ndonnx.promote_nullable` is now publicly exported
+
 0.5.0 (2024-07-01)
 ------------------
 

--- a/ndonnx/__init__.py
+++ b/ndonnx/__init__.py
@@ -18,6 +18,7 @@ from ._data_types import (
     NullableIntegral,
     NullableNumerical,
     Numerical,
+    promote_nullable,
     from_numpy_dtype,
     bool,
     float32,

--- a/ndonnx/_data_types/__init__.py
+++ b/ndonnx/_data_types/__init__.py
@@ -51,6 +51,7 @@ from .schema import Schema
 from .structtype import StructType
 
 
+# TODO: to be removed
 def promote_nullable(dtype: StructType | CoreType) -> _NullableCore:
     """Promotes a non-nullable type to its nullable counterpart, if present.
 

--- a/ndonnx/_data_types/__init__.py
+++ b/ndonnx/_data_types/__init__.py
@@ -72,7 +72,7 @@ def promote_nullable(dtype: StructType | CoreType) -> _NullableCore:
     """
 
     warn(
-        "Function 'ndonnx.promote_nullable' is to be deprecated. "
+        "Function 'ndonnx.promote_nullable' will be deprecated in ndonnx 0.7. "
         "To create nullable array, use 'ndonnx.additional.make_nullable' instead.",
         DeprecationWarning,
     )

--- a/ndonnx/_data_types/__init__.py
+++ b/ndonnx/_data_types/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations
+from warnings import warn
 
 from .aliases import (
     bool,
@@ -68,6 +69,12 @@ def promote_nullable(dtype: StructType | CoreType) -> _NullableCore:
     ValueError
         If the input type is unknown to ``ndonnx``.
     """
+
+    warn(
+        "This function 'ndonnx.promote_nullable' is to be deprecated. "
+        "To create nullable array, use 'ndonnx.additional.make_nullable' instead.",
+        DeprecationWarning,
+    )
 
     if dtype == bool:
         return nbool

--- a/ndonnx/_data_types/__init__.py
+++ b/ndonnx/_data_types/__init__.py
@@ -71,7 +71,7 @@ def promote_nullable(dtype: StructType | CoreType) -> _NullableCore:
     """
 
     warn(
-        "This function 'ndonnx.promote_nullable' is to be deprecated. "
+        "Function 'ndonnx.promote_nullable' is to be deprecated. "
         "To create nullable array, use 'ndonnx.additional.make_nullable' instead.",
         DeprecationWarning,
     )


### PR DESCRIPTION
## Bug
`promote_nullable` is publicly exposed, but it's not working because it is not imported properly in the init file.

## Changes
Add import `promote_nullable` in `ndonnx.__init__` 