### PR TITLE
Allow user defined data type operations with core types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,5 @@
 name: CI
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+on: [push, pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,8 +11,7 @@ Changelog
 
 **New features**
 
-- ``result_type`` now raises a ``PromotionError`` if the input types are not compatible.
-
+- :func:`~ndonnx.result_type` now raises a :class:`~ndonnx.PromotionError` if the input types are not compatible.
 
 0.6.1 (2024-07-12)
 ------------------

--- a/ndonnx/__init__.py
+++ b/ndonnx/__init__.py
@@ -163,6 +163,7 @@ from ._constants import (
     nan,
     pi,
 )
+from ._utility import PromotionError
 
 try:
     __version__ = importlib.metadata.version(__name__)
@@ -323,6 +324,7 @@ __all__ = [
     "Integral",
     "CoreType",
     "CastError",
+    "PromotionError",
     "promote_nullable",
     "from_numpy_dtype",
 ]

--- a/ndonnx/_core/_impl.py
+++ b/ndonnx/_core/_impl.py
@@ -38,8 +38,7 @@ class CoreOperationsImpl(OperationsBlock):
 
     def add(self, x, y) -> ndx.Array:
         x, y = promote(x, y)
-        out_dtype = x.dtype
-        if out_dtype in (ndx.nutf8, ndx.utf8):
+        if x.dtype in (dtypes.utf8, dtypes.nutf8):
             return _binary_op(x, y, opx.string_concat)
         return _via_i64_f64(opx.add, [x, y])
 
@@ -919,9 +918,7 @@ def _variadic_op(
     args = promote(*args)
     out_dtype = args[0].dtype
     if not isinstance(out_dtype, (dtypes.CoreType, dtypes._NullableCore)):
-        raise TypeError(
-            f"Expected ndx.Array with CoreType or NullableCoreType, got {args[0].dtype}"
-        )
+        return NotImplemented
     data, nulls = _split_nulls_and_values(*args)
     if via_dtype is None:
         values = _from_corearray(op(*(x._core() for x in data)))

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -290,7 +290,7 @@ def result_type(
                 np_dtypes.append(dtype.values.to_numpy_dtype())
             else:
                 raise PromotionError(
-                    "result_type is not defined for arbitrary Struct types. You likely need to explicitly cast to the desired dtype."
+                    "'result_type' is not defined for arbitrary struct types. You likely need to cast to the desired dtype explicitly."
                 )
         else:
             np_dtypes.append(dtype.to_numpy_dtype())

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -281,10 +281,6 @@ def result_type(
     *objects: dtypes.CoreType | dtypes.StructType | Array,
 ) -> dtypes.CoreType | dtypes.StructType:
     observed_dtypes = {obj.dtype if isinstance(obj, Array) else obj for obj in objects}
-
-    if len(observed_dtypes) == 1:
-        return next(iter(observed_dtypes))
-
     nullable = False
     np_dtypes = []
     for dtype in observed_dtypes:

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -410,8 +410,11 @@ def _binary(func_name, x, y):
 
 def _unary(func_name, x):
     x = asarray(x)
-    if (out := getattr(x.dtype._ops, func_name)(x)) is not NotImplemented:
-        return out
+    try:
+        if (out := getattr(x.dtype._ops, func_name)(x)) is not NotImplemented:
+            return out
+    except PromotionError:
+        pass
     raise TypeError(f"Unsupported operand type for {func_name}: '{x.dtype}'")
 
 

--- a/ndonnx/notes.txt
+++ b/ndonnx/notes.txt
@@ -1,3 +1,0 @@
-1. binary ops with core types and udts raise exception
-2. __getattr__ exposes fields - probably shouldn't
-3. _fields method in array

--- a/ndonnx/notes.txt
+++ b/ndonnx/notes.txt
@@ -1,0 +1,3 @@
+1. binary ops with core types and udts raise exception
+2. __getattr__ exposes fields - probably shouldn't
+3. _fields method in array


### PR DESCRIPTION
Currently, if you define your own data type as a user (an experimental feature!), you can happily implement many functions especially if the operands are themselves user-defined data types. However, if you do a binary operation like addition between a i64 and a custom type, type promotion fails since arbitrary dtypes cannot safely be added to the [type-promotion hierarchy](https://data-apis.org/array-api/latest/API_specification/type_promotion.html#type-promotion). Promotion occurs in the implementation of `add` and many other functions for the types exposed by ndonnx.

We should retain this restriction on type promotion but allow custom type implementers to implement binary operations that interact directly with Array API dtypes.

cc @MatejUrbanQC 