### PR TITLE
Fix broadcast_arrays for user-defined data types

### DIFF
--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -586,7 +586,7 @@ def broadcast_arrays(*arrays):
         if isinstance(x.dtype, dtypes.NullableNumerical):
             return x
         else:
-            return zeros_like(x)
+            return zeros_like(x, dtype=dtypes.int64)
 
     ret = numeric_like(next(it))
     while (x := next(it, None)) is not None:


### PR DESCRIPTION
zeros_like needs an explicite dtype, otherwise it will try to cast the value to the dtype of the original array. This can fail for user-defined data types.