### PR TITLE
Cast back to input dtype in `where`

### DIFF
--- a/ndonnx/_core/_impl.py
+++ b/ndonnx/_core/_impl.py
@@ -520,7 +520,7 @@ class CoreOperationsImpl(OperationsBlock):
                         a.astype(dtypes.int32)._core(),
                         b.astype(dtypes.int32)._core(),
                     )
-                )
+                ).astype(a.dtype)
             elif isinstance(a.dtype, dtypes.CoreType):
                 return _from_corearray(
                     opx.where(


### PR DESCRIPTION
Previously `ndx.where(ndx.asarray([True, False]), ndx.asarray([0, 1], ndx.int8), ndx.asarray([2, 3], ndx.int8))` would yield an `int32` output. This upcasting is due to the fact that onnxruntime does not implement `int8` and `int16` kernels, but a respective downcast should exist so the output of `ndx.where` has the dtype of its promoted arguments.

