### PR TITLE
Use ``float32`` in ``where``

### DIFF
--- a/ndonnx/_core/_impl.py
+++ b/ndonnx/_core/_impl.py
@@ -521,6 +521,14 @@ class CoreOperationsImpl(OperationsBlock):
                         b.astype(dtypes.int32)._core(),
                     )
                 )
+            elif a.dtype in (dtypes.uint16, dtypes.uint32, dtypes.uint64):
+                return _from_corearray(
+                    opx.where(
+                        condition_values._core(),
+                        a.astype(dtypes.int64)._core(),
+                        b.astype(dtypes.int64)._core(),
+                    )
+                ).astype(a.dtype)
             elif isinstance(a.dtype, dtypes.CoreType):
                 return _from_corearray(
                     opx.where(

--- a/ndonnx/_core/_impl.py
+++ b/ndonnx/_core/_impl.py
@@ -1051,7 +1051,7 @@ def _via_upcast(
             via_dtype = int_dtype
         else:
             raise TypeError(
-                f"Can't upcast unsigned type {dtype}. Available implementations are for {*available_types,}"
+                f"Can't upcast unsigned type `{dtype}`. Available implementations are for `{*available_types,}`"
             )
     elif isinstance(dtype, (dtypes.Integral, dtypes.NullableIntegral)) or dtype in (
         dtypes.nbool,

--- a/ndonnx/_core/_impl.py
+++ b/ndonnx/_core/_impl.py
@@ -733,7 +733,7 @@ class CoreOperationsImpl(OperationsBlock):
         if dtype is not None:
             x = x.astype(dtype)
 
-        out = _via_i64_f32(
+        out = _via_upcast(
             lambda x: opx.reduce_prod(
                 x,
                 opx.const(axes, dtype=dtypes.int64),
@@ -741,6 +741,8 @@ class CoreOperationsImpl(OperationsBlock):
                 noop_with_empty_axes=axis is not None,
             ),
             [x],
+            int_dtype=dtypes.int64,
+            float_dtype=dtypes.float32,
         )
 
         if isinstance(x.dtype, dtypes.Unsigned):
@@ -1011,6 +1013,72 @@ def _via_dtype(
         return out_value
 
 
+def _via_upcast(
+    fn: Callable[..., _CoreArray],
+    arrays: list[Array],
+    *,
+    int_dtype: dtypes.Integral | None = None,
+    float_dtype: dtypes.Floating | None = None,
+    uint_dtype: dtypes.Unsigned | None = None,
+    use_unsafe_uint_cast=False,
+    cast_return=True,
+) -> ndx.Array:
+    """Like ``_via_dtype`` but chooses a dtype from the available that doesn't result in
+    loss.
+
+    Raises TypeError for non-numerical types and if the type can't be safely casted to
+    any available type.
+    """
+    promoted_values = promote(*arrays)
+
+    dtype = promoted_values[0].dtype
+
+    # For logging
+    available_types = [t for t in [int_dtype, float_dtype, uint_dtype] if t is not None]
+
+    via_dtype: dtypes.CoreType
+    if isinstance(dtype, (dtypes.Unsigned, dtypes.NullableUnsigned)):
+        if (
+            uint_dtype is not None
+            and ndx.iinfo(dtype).bits <= ndx.iinfo(uint_dtype).bits
+        ):
+            via_dtype = uint_dtype
+        elif int_dtype is not None and ndx.iinfo(dtype).bits <= (
+            ndx.iinfo(int_dtype).bits
+            if use_unsafe_uint_cast
+            else ndx.iinfo(int_dtype).bits - 1
+        ):
+            via_dtype = int_dtype
+        else:
+            raise TypeError(
+                f"Can't upcast unsigned type {dtype}. Available implementations are for {*available_types,}"
+            )
+    elif isinstance(dtype, (dtypes.Integral, dtypes.NullableIntegral)) or dtype in (
+        dtypes.nbool,
+        dtypes.bool,
+    ):
+        if int_dtype is not None and ndx.iinfo(dtype).bits <= ndx.iinfo(int_dtype).bits:
+            via_dtype = int_dtype
+        else:
+            raise TypeError(
+                f"Can't upcast signed type {dtype}. Available implementations are for {*available_types,}"
+            )
+    elif isinstance(dtype, (dtypes.Floating, dtypes.NullableFloating)):
+        if (
+            float_dtype is not None
+            and ndx.finfo(dtype).bits <= ndx.finfo(float_dtype).bits
+        ):
+            via_dtype = float_dtype
+        else:
+            raise TypeError(
+                f"Can't upcast float type {dtype}. Available implementations are for {*available_types,}"
+            )
+    else:
+        raise TypeError(f"Expected numerical data type, found {dtype}")
+
+    return _variadic_op(arrays, fn, via_dtype, cast_return)
+
+
 def _via_i64_f64(
     fn: Callable[..., _CoreArray], arrays: list[Array], *, cast_return=True
 ) -> ndx.Array:
@@ -1019,22 +1087,14 @@ def _via_i64_f64(
 
     Raises TypeError if the provided arrays are neither.
     """
-    promoted_values = promote(*arrays)
-
-    dtype = promoted_values[0].dtype
-
-    via_dtype: dtypes.CoreType
-    if isinstance(dtype, (dtypes.Integral, dtypes.NullableIntegral)) or dtype in (
-        dtypes.nbool,
-        dtypes.bool,
-    ):
-        via_dtype = dtypes.int64
-    elif isinstance(dtype, (dtypes.Floating, dtypes.NullableFloating)):
-        via_dtype = dtypes.float64
-    else:
-        raise TypeError(f"Expected numerical data type, found {dtype}")
-
-    return _variadic_op(arrays, fn, via_dtype, cast_return)
+    return _via_upcast(
+        fn,
+        arrays,
+        int_dtype=dtypes.int64,
+        float_dtype=dtypes.float64,
+        use_unsafe_uint_cast=True,  # TODO this can cause overflow, we should set it to false and fix all uses
+        cast_return=cast_return,
+    )
 
 
 def _via_i64_f32(

--- a/ndonnx/_core/_impl.py
+++ b/ndonnx/_core/_impl.py
@@ -1061,7 +1061,7 @@ def _via_upcast(
             via_dtype = int_dtype
         else:
             raise TypeError(
-                f"Can't upcast signed type {dtype}. Available implementations are for {*available_types,}"
+                f"Can't upcast signed type `{dtype}`. Available implementations are for `{*available_types,}`"
             )
     elif isinstance(dtype, (dtypes.Floating, dtypes.NullableFloating)):
         if (
@@ -1071,7 +1071,7 @@ def _via_upcast(
             via_dtype = float_dtype
         else:
             raise TypeError(
-                f"Can't upcast float type {dtype}. Available implementations are for {*available_types,}"
+                f"Can't upcast float type `{dtype}`. Available implementations are for `{*available_types,}`"
             )
     else:
         raise TypeError(f"Expected numerical data type, found {dtype}")

--- a/ndonnx/_core/_impl.py
+++ b/ndonnx/_core/_impl.py
@@ -1026,8 +1026,11 @@ def _via_upcast(
     """Like ``_via_dtype`` but chooses a dtype from the available that doesn't result in
     loss.
 
-    Raises TypeError for non-numerical types and if the type can't be safely casted to
-    any available type.
+    Raises
+    ------
+    TypeError
+        For non-numerical types and if the type can't be safely casted to
+        any available type.
     """
     promoted_values = promote(*arrays)
 

--- a/ndonnx/_core/_impl.py
+++ b/ndonnx/_core/_impl.py
@@ -1097,34 +1097,6 @@ def _via_i64_f64(
     )
 
 
-def _via_i64_f32(
-    fn: Callable[..., _CoreArray], arrays: list[Array], *, cast_return=True
-) -> ndx.Array:
-    """Like ``_via_dtype`` but uses ``i64`` for integer or boolean types and ``float32``
-    for floating point types except ``float64`` and ``nfloat64``.
-
-    Raises TypeError if the provided arrays are neither.
-    """
-    promoted_values = promote(*arrays)
-
-    dtype = promoted_values[0].dtype
-
-    via_dtype: dtypes.CoreType
-    if isinstance(dtype, (dtypes.Integral, dtypes.NullableIntegral)) or dtype in (
-        dtypes.nbool,
-        dtypes.bool,
-    ):
-        via_dtype = dtypes.int64
-    elif isinstance(dtype, (dtypes.Floating, dtypes.NullableFloating)):
-        if dtype in (dtypes.float64, dtypes.nfloat64):
-            raise TypeError("No implementation for float64 in onnxruntime")
-        via_dtype = dtypes.float32
-    else:
-        raise TypeError(f"Expected numerical data type, found {dtype}")
-
-    return _variadic_op(arrays, fn, via_dtype, cast_return)
-
-
 def _from_corearray(
     corearray: _CoreArray,
 ) -> ndx.Array:

--- a/tests/ndonnx/test_core.py
+++ b/tests/ndonnx/test_core.py
@@ -557,11 +557,9 @@ def test_truediv():
         ndx.uint8,
         ndx.uint16,
         ndx.uint32,
-        ndx.uint64,
         ndx.nuint8,
         ndx.nuint16,
         ndx.nuint32,
-        ndx.nuint64,
     ],
 )
 def test_prod(dtype):
@@ -576,9 +574,11 @@ def test_prod(dtype):
     [
         ndx.float64,
         ndx.nfloat64,
+        ndx.uint64,
+        ndx.nuint64,
     ],
 )
-def test_prod_f64(dtype):
+def test_prod_no_implementation(dtype):
     x = ndx.asarray([2, 2]).astype(dtype)
     with pytest.raises(TypeError):
         ndx.prod(x)

--- a/tests/ndonnx/test_core.py
+++ b/tests/ndonnx/test_core.py
@@ -539,3 +539,46 @@ def test_truediv():
     z = x / y
     assert isinstance(z.dtype, ndx.Floating)
     np.testing.assert_array_equal(z.to_numpy(), np.array([0.5, 2 / 3, 1.0]))
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ndx.float32,
+        ndx.nfloat32,
+        ndx.int8,
+        ndx.int16,
+        ndx.int32,
+        ndx.int64,
+        ndx.nint8,
+        ndx.nint16,
+        ndx.nint32,
+        ndx.nint64,
+        ndx.uint8,
+        ndx.uint16,
+        ndx.uint32,
+        ndx.uint64,
+        ndx.nuint8,
+        ndx.nuint16,
+        ndx.nuint32,
+        ndx.nuint64,
+    ],
+)
+def test_prod(dtype):
+    x = ndx.asarray([2, 2]).astype(dtype)
+    y = ndx.prod(x)
+
+    np.testing.assert_array_equal(y.to_numpy(), np.array(4))
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ndx.float64,
+        ndx.nfloat64,
+    ],
+)
+def test_prod_f64(dtype):
+    x = ndx.asarray([2, 2]).astype(dtype)
+    with pytest.raises(TypeError):
+        ndx.prod(x)


### PR DESCRIPTION
Onnxruntime doesn't implement ``ReduceProd`` for ``float64``. We will error for
``float64`` and otherwise use ``float32``.

Also fixes the implementation for unsigned integers