### PR TITLE
Allow `full` to work with scalar shapes.

### DIFF
--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -144,10 +144,12 @@ def full(
         raise ValueError("fill_value must be a scalar")
 
     dtype = fill_value.dtype if dtype is None else dtype
-    shape = asarray(shape, dtype=dtypes.int64)._core()
-    return fill_value._transmute(lambda corearray: opx.expand(corearray, shape)).astype(
-        dtype
-    )
+    shape = asarray(shape, dtype=dtypes.int64)
+    if shape.ndim == 0:
+        shape = reshape(shape, [1])
+    return fill_value._transmute(
+        lambda corearray: opx.expand(corearray, shape._core())
+    ).astype(dtype)
 
 
 def full_like(

--- a/tests/ndonnx/test_core.py
+++ b/tests/ndonnx/test_core.py
@@ -435,6 +435,25 @@ def test_creation_full():
     c = ndx.full((2, 3), "a", dtype=ndx.nutf8)
     np.testing.assert_equal(np.full((2, 3), "a"), c.to_numpy())
 
+    d = ndx.full(2, 5, dtype=ndx.int8)
+    np.testing.assert_equal(np.full(2, 5, dtype=np.int8), d.to_numpy())
+
+    # Check lazy creation
+    e = ndx.array(shape=tuple(), dtype=ndx.int64)
+    f = ndx.full(e, 10)
+    model_proto = ndx.build({"e": e}, {"f": f})
+    actual = run(model_proto, {"e": np.array(5, dtype=np.int64)})["f"]
+    np.testing.assert_equal(np.array([10] * 5, dtype=np.int64), actual)
+
+    # Note we must know the output shape to export an ONNX artifact.
+    g = ndx.array(shape=(2,), dtype=ndx.int64)
+    h = ndx.full(g, 10)
+    model_proto = ndx.build({"g": g}, {"h": h})
+    np.testing.assert_equal(
+        np.array([[10, 10, 10], [10, 10, 10]]),
+        run(model_proto, {"g": np.array([2, 3])})["h"],
+    )
+
 
 @pytest.mark.parametrize(
     "args, expected",


### PR DESCRIPTION
Currently, because the ONNX shape operator requires a 1D tensor as input, doing `ndx.full` with a scalar and lazy shape fails. This PR adds the extra dimension if the rank of the shape is 0. 

Note that we generally expect the rank to be known statically from ONNX shape inference and `ndx.Array.ndim` returns an int. You can construct specific cases where even the rank is data-dependent.