### PR TITLE
Update array-api-tests and run against newer version

### DIFF
--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Run Array API tests
         env:
           ARRAY_API_TESTS_MODULE: ndonnx
+          ARRAY_API_TESTS_VERSION: "2023.12"
+          ARRAY_API_TESTS_SKIP_DTYPES: complex64,complex128
         run: |
           pushd api-coverage-tests
           pixi run pytest --ci --max-examples 2 array_api_tests/ --json-report --json-report-file=api-coverage-tests.json -n auto -vv --skips-file=../skips.txt


### PR DESCRIPTION
This PR updates the array-api-tests submodule and tests against a more recent version of the standard. It requires the complex data types to load (#32 ). The latest test suite gives a decent amount of failures to work through.