### PR TITLE
Fix cross-kind promotions

### DIFF
--- a/ndonnx/_core/_impl.py
+++ b/ndonnx/_core/_impl.py
@@ -199,10 +199,10 @@ class CoreOperationsImpl(OperationsBlock):
         return self.add(self.log(x), ndx.asarray(1, x.dtype))
 
     def log2(self, x):
-        return ndx.log(x) / np.log(2)
+        return ndx.log(x) / float(np.log(2))
 
     def log10(self, x):
-        return ndx.log(x) / np.log(10)
+        return ndx.log(x) / float(np.log(10))
 
     def logaddexp(self, x, y):
         return self.log(self.exp(x) + self.exp(y))

--- a/ndonnx/_utility.py
+++ b/ndonnx/_utility.py
@@ -34,9 +34,9 @@ def promote(*args: Array | npt.ArrayLike | None) -> list[Array]:
     for arg in args:
         if isinstance(arg, ndx.Array):
             arrays.append(arg)
-        elif isinstance(arg, np.ndarray):
+        elif isinstance(arg, (np.ndarray, np.generic)):
             arrays.append(ndx.asarray(arg))
-        elif isinstance(arg, (float, int, str, np.generic)):
+        elif isinstance(arg, (float, int, str)):
             continue
         else:
             raise TypeError(f"Cannot promote {type(arg)}")

--- a/ndonnx/_utility.py
+++ b/ndonnx/_utility.py
@@ -30,17 +30,14 @@ def promote(*args: Array | npt.ArrayLike | None) -> list[Array]:
     `None` values are passed through.
     """
     arrays: list[Array] = []
-    all_arguments: list[Array] = []
 
     for arg in args:
         if isinstance(arg, ndx.Array):
             arrays.append(arg)
-            all_arguments.append(arg)
         elif isinstance(arg, np.ndarray):
             arrays.append(ndx.asarray(arg))
-            all_arguments.append(arrays[-1])
         elif isinstance(arg, (float, int, str, np.generic)):
-            all_arguments.append(ndx.asarray(arg))
+            continue
         else:
             raise TypeError(f"Cannot promote {type(arg)}")
 
@@ -50,12 +47,26 @@ def promote(*args: Array | npt.ArrayLike | None) -> list[Array]:
     target_dtype = ndx.result_type(*arrays)
     string_dtypes = (ndx.utf8, ndx.nutf8)
     out: list[Array] = []
-    for arr in all_arguments:
-        if arr.dtype in string_dtypes and target_dtype not in string_dtypes:
+    for arg in args:
+        # Deal with cross-kind scalar promotions
+        if isinstance(arg, float) and not isinstance(
+            target_dtype, (ndx.Floating, ndx.NullableFloating)
+        ):
+            target_dtype = ndx.result_type(target_dtype, ndx.float64)
+        elif isinstance(arg, bool) and not target_dtype not in (ndx.bool, ndx.nbool):
+            target_dtype = ndx.result_type(target_dtype, ndx.bool)
+        elif isinstance(arg, int) and not isinstance(
+            target_dtype, (ndx.Numerical, ndx.NullableNumerical)
+        ):
+            target_dtype = ndx.result_type(target_dtype, ndx.int64)
+
+        if not isinstance(arg, ndx.Array):
+            arg = ndx.asarray(np.array(arg))
+        if arg.dtype in string_dtypes and target_dtype not in string_dtypes:
             raise TypeError("Cannot promote string scalar to numerical type")
-        elif arr.dtype not in string_dtypes and target_dtype in string_dtypes:
+        elif arg.dtype not in string_dtypes and target_dtype in string_dtypes:
             raise TypeError("Cannot promote non string scalar to string type")
-        out.append(arr.astype(target_dtype))
+        out.append(arg.astype(target_dtype))
 
     return out
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -719,20 +719,20 @@ def test_promotion_failures(arrays, scalar):
 @pytest.mark.parametrize(
     "x, y",
     [
-        (ndx.asarray([1, 2, 3], dtype=ndx.int64), 1.12),
-        (1.23, ndx.asarray([1, 2, 3], dtype=ndx.int64)),
-        (True, ndx.asarray([1, 2, 3], dtype=ndx.int8)),
-        (ndx.asarray([True, False]), 1.12),
-        (ndx.asarray([True, False]), 4),
-        (ndx.asarray([1.23, 2.34]), True),
-        (ndx.asarray([1.23, 2.34]), 2),
+        (np.asarray([1, 2, 3], dtype=np.int64), 1.12),
+        (1.23, np.asarray([1, 2, 3], dtype=np.int64)),
+        (True, np.asarray([1, 2, 3], dtype=np.int8)),
+        (np.asarray([True, False]), 1.12),
+        (np.asarray([True, False]), 4),
+        (np.asarray([1.23, 2.34]), True),
+        (np.asarray([1.23, 2.34]), 2),
     ],
 )
 def test_cross_kind_promotions(x, y):
-    onnx_result = x + y
-    if isinstance(x, ndx.Array):
-        x = x.to_numpy()
-    if isinstance(y, ndx.Array):
-        y = y.to_numpy()
     np_result = x + y
+    if isinstance(x, np.ndarray):
+        x = ndx.asarray(x)
+    if isinstance(y, np.ndarray):
+        y = ndx.asarray(y)
+    onnx_result = x + y
     np.testing.assert_equal(onnx_result.to_numpy(), np_result)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -714,3 +714,25 @@ def test_scalar_promote(arrays, scalar):
 def test_promotion_failures(arrays, scalar):
     with pytest.raises(TypeError, match="Cannot promote"):
         promote(*arrays, scalar)
+
+
+@pytest.mark.parametrize(
+    "x, y",
+    [
+        (ndx.asarray([1, 2, 3], dtype=ndx.int64), 1.12),
+        (1.23, ndx.asarray([1, 2, 3], dtype=ndx.int64)),
+        (True, ndx.asarray([1, 2, 3], dtype=ndx.int8)),
+        (ndx.asarray([True, False]), 1.12),
+        (ndx.asarray([True, False]), 4),
+        (ndx.asarray([1.23, 2.34]), True),
+        (ndx.asarray([1.23, 2.34]), 2),
+    ],
+)
+def test_cross_kind_promotions(x, y):
+    onnx_result = x + y
+    if isinstance(x, ndx.Array):
+        x = x.to_numpy()
+    if isinstance(y, ndx.Array):
+        y = y.to_numpy()
+    np_result = x + y
+    np.testing.assert_equal(onnx_result.to_numpy(), np_result)


### PR DESCRIPTION
The previous promotion improvement neglected to account for cross-kind promotions between bools, ints and floats. These were automatically handled in the previous implementation. This leads to results like the following, which are resolved in this PR:

```
(Pdb) np.asarray([1, 2]) + 2.32
array([3.32, 4.32])
(Pdb) ndx.asarray([1, 2]) + 2.32
Array([3 4], dtype=Int64)
```