### PR TITLE
Fix error message if full_like is not implemented

### DIFF
--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -137,7 +137,7 @@ def full_like(
     ) is not NotImplemented:
         return out
     raise UnsupportedOperationError(
-        f"Unsupported operand type for full_like: '{x.dtype}'"
+        f"Unsupported operand type for full_like: `{x.dtype}`"
     )
 
 

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -137,7 +137,7 @@ def full_like(
     ) is not NotImplemented:
         return out
     raise UnsupportedOperationError(
-        f"Unsupported operand type for full_like: '{dtype}'"
+        f"Unsupported operand type for full_like: '{x.dtype}'"
     )
 
 


### PR DESCRIPTION
Small mistake in the error message is printed if a dtype has not implemented `full_like`.