### PR TITLE
Split out nullable implementation block

### DIFF
--- a/ndonnx/_core/__init__.py
+++ b/ndonnx/_core/__init__.py
@@ -1,17 +1,22 @@
 # Copyright (c) QuantCo 2023-2024
 # SPDX-License-Identifier: BSD-3-Clause
 
-from ._numericimpl import NumericOperationsImpl
-from ._stringimpl import StringOperationsImpl
-from ._boolimpl import BooleanOperationsImpl
+from ._numericimpl import NumericOperationsImpl, NullableNumericOperationsImpl
+from ._stringimpl import StringOperationsImpl, NullableStringOperationsImpl
+from ._boolimpl import BooleanOperationsImpl, NullableBooleanOperationsImpl
 from ._interface import OperationsBlock
 from ._shapeimpl import UniformShapeOperations
+from ._nullableimpl import NullableOperationsImpl
 
 __all__ = [
     "NumericOperationsImpl",
     "StringOperationsImpl",
     "BooleanOperationsImpl",
     "UniformShapeOperations",
+    "NullableOperationsImpl",
+    "NullableNumericOperationsImpl",
+    "NullableStringOperationsImpl",
+    "NullableBooleanOperationsImpl",
     "OperationsBlock",
     "binary_op",
     "unary_op",

--- a/ndonnx/_core/__init__.py
+++ b/ndonnx/_core/__init__.py
@@ -6,14 +6,12 @@ from ._stringimpl import StringOperationsImpl, NullableStringOperationsImpl
 from ._boolimpl import BooleanOperationsImpl, NullableBooleanOperationsImpl
 from ._interface import OperationsBlock
 from ._shapeimpl import UniformShapeOperations
-from ._nullableimpl import NullableOperationsImpl
 
 __all__ = [
     "NumericOperationsImpl",
     "StringOperationsImpl",
     "BooleanOperationsImpl",
     "UniformShapeOperations",
-    "NullableOperationsImpl",
     "NullableNumericOperationsImpl",
     "NullableStringOperationsImpl",
     "NullableBooleanOperationsImpl",

--- a/ndonnx/_core/_boolimpl.py
+++ b/ndonnx/_core/_boolimpl.py
@@ -13,6 +13,7 @@ import ndonnx as ndx
 import ndonnx._data_types as dtypes
 import ndonnx._opset_extensions as opx
 
+from ._nullableimpl import NullableOperationsImpl
 from ._shapeimpl import UniformShapeOperations
 from ._utils import binary_op, unary_op, validate_core
 
@@ -160,3 +161,17 @@ class BooleanOperationsImpl(UniformShapeOperations):
     @validate_core
     def nonzero(self, x) -> tuple[Array, ...]:
         return ndx.nonzero(x.astype(ndx.int8))
+
+    @validate_core
+    def make_nullable(self, x, null):
+        if null.dtype != dtypes.bool:
+            raise TypeError("null must be a boolean array")
+        return ndx.Array._from_fields(
+            dtypes.into_nullable(x.dtype),
+            values=x.copy(),
+            null=ndx.reshape(null, x.shape),
+        )
+
+
+class NullableBooleanOperationsImpl(BooleanOperationsImpl, NullableOperationsImpl):
+    pass

--- a/ndonnx/_core/_boolimpl.py
+++ b/ndonnx/_core/_boolimpl.py
@@ -165,7 +165,7 @@ class BooleanOperationsImpl(UniformShapeOperations):
     @validate_core
     def make_nullable(self, x, null):
         if null.dtype != dtypes.bool:
-            raise TypeError("null must be a boolean array")
+            raise TypeError("'null' must be a boolean array")
         return ndx.Array._from_fields(
             dtypes.into_nullable(x.dtype),
             values=x.copy(),

--- a/ndonnx/_core/_boolimpl.py
+++ b/ndonnx/_core/_boolimpl.py
@@ -174,4 +174,5 @@ class BooleanOperationsImpl(UniformShapeOperations):
 
 
 class NullableBooleanOperationsImpl(BooleanOperationsImpl, NullableOperationsImpl):
-    pass
+    def make_nullable(self, x, null):
+        return NotImplemented

--- a/ndonnx/_core/_nullableimpl.py
+++ b/ndonnx/_core/_nullableimpl.py
@@ -14,6 +14,3 @@ class NullableOperationsImpl(OperationsBlock):
         if value.dtype != x.values.dtype:
             value = value.astype(x.values.dtype)
         return ndx.where(x.null, value, x.values)
-
-    def make_nullable(self, x, null):
-        return NotImplemented

--- a/ndonnx/_core/_nullableimpl.py
+++ b/ndonnx/_core/_nullableimpl.py
@@ -1,0 +1,19 @@
+# Copyright (c) QuantCo 2023-2024
+# SPDX-License-Identifier: BSD-3-Clause
+
+import ndonnx as ndx
+
+from ._interface import OperationsBlock
+from ._utils import validate_core
+
+
+class NullableOperationsImpl(OperationsBlock):
+    @validate_core
+    def fill_null(self, x, value):
+        value = ndx.asarray(value)
+        if value.dtype != x.values.dtype:
+            value = value.astype(x.values.dtype)
+        return ndx.where(x.null, value, x.values)
+
+    def make_nullable(self, x, null):
+        return NotImplemented

--- a/ndonnx/_core/_numericimpl.py
+++ b/ndonnx/_core/_numericimpl.py
@@ -804,6 +804,7 @@ class NumericOperationsImpl(UniformShapeOperations):
     def make_nullable(self, x, null):
         if null.dtype != dtypes.bool:
             raise TypeError("null must be a boolean array")
+
         return ndx.Array._from_fields(
             dtypes.into_nullable(x.dtype),
             values=x.copy(),
@@ -943,7 +944,8 @@ class NumericOperationsImpl(UniformShapeOperations):
 
 
 class NullableNumericOperationsImpl(NumericOperationsImpl, NullableOperationsImpl):
-    pass
+    def make_nullable(self, x, null):
+        return NotImplemented
 
 
 def _via_i64_f64(

--- a/ndonnx/_core/_numericimpl.py
+++ b/ndonnx/_core/_numericimpl.py
@@ -18,6 +18,7 @@ import ndonnx._data_types as dtypes
 import ndonnx._opset_extensions as opx
 from ndonnx._utility import promote
 
+from ._nullableimpl import NullableOperationsImpl
 from ._shapeimpl import UniformShapeOperations
 from ._utils import (
     binary_op,
@@ -799,24 +800,10 @@ class NumericOperationsImpl(UniformShapeOperations):
             - correction
         )
 
-    # additional.py
-    @validate_core
-    def fill_null(self, x, value):
-        value = ndx.asarray(value)
-
-        if not isinstance(x.dtype, dtypes._NullableCore):
-            raise TypeError("fill_null accepts only nullable arrays")
-
-        if value.dtype != x.values.dtype:
-            value = value.astype(x.values.dtype)
-        return ndx.where(x.null, value, x.values)
-
     @validate_core
     def make_nullable(self, x, null):
         if null.dtype != dtypes.bool:
             raise TypeError("null must be a boolean array")
-        if not isinstance(x.dtype, dtypes.CoreType):
-            raise TypeError("'make_nullable' does not accept nullable arrays")
         return ndx.Array._from_fields(
             dtypes.into_nullable(x.dtype),
             values=x.copy(),
@@ -953,6 +940,10 @@ class NumericOperationsImpl(UniformShapeOperations):
     @validate_core
     def empty_like(self, x, dtype=None, device=None) -> ndx.Array:
         return ndx.full_like(x, 0, dtype=dtype)
+
+
+class NullableNumericOperationsImpl(NumericOperationsImpl, NullableOperationsImpl):
+    pass
 
 
 def _via_i64_f64(

--- a/ndonnx/_core/_numericimpl.py
+++ b/ndonnx/_core/_numericimpl.py
@@ -803,7 +803,7 @@ class NumericOperationsImpl(UniformShapeOperations):
     @validate_core
     def make_nullable(self, x, null):
         if null.dtype != dtypes.bool:
-            raise TypeError("null must be a boolean array")
+            raise TypeError("'null' must be a boolean array")
 
         return ndx.Array._from_fields(
             dtypes.into_nullable(x.dtype),

--- a/ndonnx/_core/_stringimpl.py
+++ b/ndonnx/_core/_stringimpl.py
@@ -64,7 +64,7 @@ class StringOperationsImpl(UniformShapeOperations):
     @validate_core
     def make_nullable(self, x, null):
         if null.dtype != dtypes.bool:
-            raise TypeError("null must be a boolean array")
+            raise TypeError("'null' must be a boolean array")
 
         return ndx.Array._from_fields(
             dtypes.into_nullable(x.dtype),

--- a/ndonnx/_core/_stringimpl.py
+++ b/ndonnx/_core/_stringimpl.py
@@ -65,6 +65,7 @@ class StringOperationsImpl(UniformShapeOperations):
     def make_nullable(self, x, null):
         if null.dtype != dtypes.bool:
             raise TypeError("null must be a boolean array")
+
         return ndx.Array._from_fields(
             dtypes.into_nullable(x.dtype),
             values=x.copy(),
@@ -72,4 +73,6 @@ class StringOperationsImpl(UniformShapeOperations):
         )
 
 
-class NullableStringOperationsImpl(StringOperationsImpl, NullableOperationsImpl): ...
+class NullableStringOperationsImpl(StringOperationsImpl, NullableOperationsImpl):
+    def make_nullable(self, x, null):
+        return NotImplemented

--- a/ndonnx/_core/_stringimpl.py
+++ b/ndonnx/_core/_stringimpl.py
@@ -11,6 +11,7 @@ import ndonnx as ndx
 import ndonnx._data_types as dtypes
 import ndonnx._opset_extensions as opx
 
+from ._nullableimpl import NullableOperationsImpl
 from ._shapeimpl import UniformShapeOperations
 from ._utils import binary_op, validate_core
 
@@ -59,3 +60,16 @@ class StringOperationsImpl(UniformShapeOperations):
     @validate_core
     def empty_like(self, x, dtype=None, device=None) -> ndx.Array:
         return ndx.zeros_like(x, dtype=dtype, device=device)
+
+    @validate_core
+    def make_nullable(self, x, null):
+        if null.dtype != dtypes.bool:
+            raise TypeError("null must be a boolean array")
+        return ndx.Array._from_fields(
+            dtypes.into_nullable(x.dtype),
+            values=x.copy(),
+            null=ndx.reshape(null, x.shape),
+        )
+
+
+class NullableStringOperationsImpl(StringOperationsImpl, NullableOperationsImpl): ...

--- a/ndonnx/_data_types/classes.py
+++ b/ndonnx/_data_types/classes.py
@@ -12,6 +12,9 @@ from typing_extensions import Self
 import ndonnx as ndx
 from ndonnx._core import (
     BooleanOperationsImpl,
+    NullableBooleanOperationsImpl,
+    NullableNumericOperationsImpl,
+    NullableStringOperationsImpl,
     NumericOperationsImpl,
     OperationsBlock,
     StringOperationsImpl,
@@ -240,7 +243,7 @@ class _NullableCore(Nullable[CoreType], CastMixin):
 class NullableNumerical(_NullableCore):
     """Base class for nullable numerical data types."""
 
-    _ops: OperationsBlock = NumericOperationsImpl()
+    _ops: OperationsBlock = NullableNumericOperationsImpl()
 
 
 class NullableIntegral(NullableNumerical):
@@ -313,14 +316,14 @@ class NBoolean(_NullableCore):
     values = Boolean()
     null = Boolean()
 
-    _ops: OperationsBlock = BooleanOperationsImpl()
+    _ops: OperationsBlock = NullableBooleanOperationsImpl()
 
 
 class NUtf8(_NullableCore):
     values = Utf8()
     null = Boolean()
 
-    _ops: OperationsBlock = StringOperationsImpl()
+    _ops: OperationsBlock = NullableStringOperationsImpl()
 
 
 def from_numpy_dtype(np_dtype: np.dtype) -> CoreType:

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -36,7 +36,11 @@ def arange(
     device=None,
 ):
     if dtype is None:
-        if builtins.all(isinstance(x, int) for x in [start, stop, step]):
+        if builtins.all(
+            isinstance(asarray(x).dtype, dtypes.Integral)
+            for x in [start, stop, step]
+            if x is not None
+        ):
             dtype = dtypes.int64
         else:
             dtype = dtypes.float64


### PR DESCRIPTION
This PR splits out implementations of functions for nullable dtypes. It doesn't take things very far and only fixes a bug around `make_nullable`.

We should take this further and start moving actual null handling out of the `via_dtype` functions and into the dtype implementation after the upcoming release.