### PR TITLE
Forbid iteration over dynamic dimensions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Changelog
 =========
 
+0.9.0 (unreleased)
+------------------
+
+**Breaking change**
+
+- Iterating over dynamic dimensions of :class:`~ndonnx.Array` is no longer allowed since it commonly lead to infinite loops when used without an explicit break condition.
+
+
 0.8.0 (2024-08-22)
 ------------------
 

--- a/ndonnx/_array.py
+++ b/ndonnx/_array.py
@@ -109,6 +109,17 @@ class Array:
         else:
             raise AttributeError(f"Field {name} not found")
 
+    def __iter__(self):
+        try:
+            n, *_ = self.shape
+        except IndexError:
+            raise ValueError("iteration over 0-d array")
+        if isinstance(n, int):
+            return (self[i, ...] for i in range(n))
+        raise ValueError(
+            "iteration requires dimension of static length, but dimension 0 is dynamic."
+        )
+
     def _set(self, other: Array) -> Array:
         self.dtype = other.dtype
         self._fields = other._fields

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -7,8 +7,7 @@ import ndonnx as ndx
 
 
 def test_iter_for_loop():
-    n = 5
-    a = ndx.array(shape=(n,), dtype=ndx.int64)
+    a = ndx.array(shape=(5,), dtype=ndx.int64)
 
     for i, el in enumerate(a):  # type: ignore
         if i > n:
@@ -29,6 +28,7 @@ def test_create_iterators(arr):
     it = iter(arr)
     el = next(it)
     assert el.ndim == arr.ndim - 1
+    assert el.shape == arr.shape[1:]
 
 
 def test_0d_not_iterable():

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -7,9 +7,11 @@ import ndonnx as ndx
 
 
 def test_iter_for_loop():
-    a = ndx.array(shape=(5,), dtype=ndx.int64)
+    n = 5
+    a = ndx.array(shape=(n,), dtype=ndx.int64)
 
     for i, el in enumerate(a):  # type: ignore
+        assert isinstance(el, ndx.Array)
         if i > n:
             assert False, "Iterated past the number of elements"
 

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -22,6 +22,7 @@ def test_iter_for_loop():
         ndx.asarray([[1], [2]]),
         ndx.array(shape=(2,), dtype=ndx.int64),
         ndx.array(shape=(2, 3), dtype=ndx.int64),
+        ndx.array(shape=(2, "N"), dtype=ndx.int64),
     ],
 )
 def test_create_iterators(arr):
@@ -34,3 +35,8 @@ def test_0d_not_iterable():
     scalar = ndx.array(shape=(), dtype=ndx.int64)
     with pytest.raises(ValueError):
         next(iter(scalar))
+
+
+def test_raises_dynamic_dim():
+    with pytest.raises(ValueError):
+        iter(ndx.array(shape=("N",), dtype=ndx.int64))

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -1,0 +1,36 @@
+# Copyright (c) QuantCo 2023-2024
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+import ndonnx as ndx
+
+
+def test_iter_for_loop():
+    n = 5
+    a = ndx.array(shape=(n,), dtype=ndx.int64)
+
+    for i, el in enumerate(a):  # type: ignore
+        if i > n:
+            assert False, "Iterated past the number of elements"
+
+
+@pytest.mark.parametrize(
+    "arr",
+    [
+        ndx.asarray([1]),
+        ndx.asarray([[1], [2]]),
+        ndx.array(shape=(2,), dtype=ndx.int64),
+        ndx.array(shape=(2, 3), dtype=ndx.int64),
+    ],
+)
+def test_create_iterators(arr):
+    it = iter(arr)
+    el = next(it)
+    assert el.ndim == arr.ndim - 1
+
+
+def test_0d_not_iterable():
+    scalar = ndx.array(shape=(), dtype=ndx.int64)
+    with pytest.raises(ValueError):
+        next(iter(scalar))


### PR DESCRIPTION
Running the scikit-learn test suite on the latest 0.8 release revealed an infinite loop when using arrays in for-loops. Namely, it turns out that the following code currently loops indefinitely:

```python
a = ndx.array(shape=(2,), dtype=ndx.int64)

for item in a:
    ...
```

Looping like this over a dimension with static size is perfectly safe and reasonable to do. This PR ensures that the iterations over dimension with static length terminate correctly. 


The issue is more delicate for an array with a dynamic length such as in the following example. 

```python
a_dyn = ndx.array(shape=("N",), dtype=ndx.int64)

for item in a_dyn:
    ...
```
While infinite generators are not uncommon in Python, they only make sense if the user breaks out of the loop in some other way. It seems rather unlikely that this is what the user has in mind when running the second example, though. 

Rather than leaving this footgun in place, this PR explicitly prohibits `__iter__`ating over arrays where the first dimension is dynamic. It also prohibits iterating over 0-d arrays which is in line with NumPy's behavior