### PR TITLE
Run Array API tests weekly

### DIFF
--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -3,7 +3,7 @@ name: Array API coverage tests
 on:
   push: # Run on all branches
   schedule:
-    - cron: "0 0 * * *" # Runs daily at 00:00 UTC
+    - cron: "* * * * *" # Runs daily at 00:00 UTC
 
 # Automatically stop old builds on the same branch/PR
 concurrency:
@@ -28,7 +28,7 @@ jobs:
       - name: Install repository
         run: pixi run postinstall
       - name: Run Array API tests (Scheduled)
-        if: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'schedule' }}
         run: pixi run arrayapitests
       - name: Run Array API tests (Push)
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -38,3 +38,25 @@ jobs:
         with:
           name: api-coverage-tests
           path: api-coverage-tests.json
+      - name: Issue on failure
+        uses: actions/github-script@v7
+        if: ${{ failure() && github.event_name == 'schedule' && github.ref == 'refs/heads/main' }}
+        with:
+          script: |
+            github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: "[bot] Weekly run"
+            }).then((issues) => {
+              if (issues.data.length === 0){
+                github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: "Weekly run failure: Array API coverage",
+                  body: "The weekly run of the Array API test suite failed. See https://github.com/Quantco/ndonnx/actions/runs/${{ github.run_id }} for details.",
+                  assignees: ["adityagoel4512", "cbourjau", "neNasko1"],
+                  labels: ["[bot] Weekly run"]
+                })
+              }
+            });

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -3,7 +3,7 @@ name: Array API coverage tests
 on:
   push: # Run on all branches
   schedule:
-    - cron: "0 8 * * *" # Runs daily at 00:00 UTC
+    - cron: "0 8 * * 0" # Runs weekly at 08:00 UTC on Sunday
 
 # Automatically stop old builds on the same branch/PR
 concurrency:

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install repository
         run: pixi run postinstall
       - name: Run Array API tests (Scheduled)
-        if: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'schedule' }}
         run: pixi run arrayapitests
       - name: Run Array API tests (Push)
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -3,7 +3,7 @@ name: Array API coverage tests
 on:
   push: {} # Run on all branches
   schedule:
-    - cron: "15 * * * *" # Runs daily at 00:00 UTC
+    - cron: "0 0 * * *" # Runs daily at 00:00 UTC
 
 # Automatically stop old builds on the same branch/PR
 concurrency:
@@ -28,7 +28,7 @@ jobs:
       - name: Install repository
         run: pixi run postinstall
       - name: Run Array API tests (Scheduled)
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/main' }}
         run: pixi run arrayapitests
       - name: Run Array API tests (Push)
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -3,7 +3,7 @@ name: Array API coverage tests
 on:
   push: {} # Run on all branches
   schedule:
-    - cron: '0 * * * *'  # Runs daily at 00:00 UTC
+    - cron: "15 * * * *" # Runs daily at 00:00 UTC
 
 # Automatically stop old builds on the same branch/PR
 concurrency:
@@ -28,7 +28,7 @@ jobs:
       - name: Install repository
         run: pixi run postinstall
       - name: Run Array API tests (Scheduled)
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/main' }}
         run: pixi run arrayapitests
       - name: Run Array API tests (Push)
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -3,7 +3,7 @@ name: Array API coverage tests
 on:
   push: {} # Run on all branches
   schedule:
-    - cron: '0 0 * * *'  # Runs daily at 00:00 UTC
+    - cron: '0 * * * *'  # Runs daily at 00:00 UTC
 
 # Automatically stop old builds on the same branch/PR
 concurrency:

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -1,7 +1,7 @@
 name: Array API coverage tests
 
 on:
-  push: {} # Run on all branches
+  push: # Run on all branches
   schedule:
     - cron: "0 0 * * *" # Runs daily at 00:00 UTC
 

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -3,7 +3,7 @@ name: Array API coverage tests
 on:
   push: # Run on all branches
   schedule:
-    - cron: "* * * * *" # Runs daily at 00:00 UTC
+    - cron: "*/5 * * * *" # Runs daily at 00:00 UTC
 
 # Automatically stop old builds on the same branch/PR
 concurrency:

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -1,5 +1,9 @@
 name: Array API coverage tests
-on: [push]
+
+on:
+  push: {} # Run on all branches
+  schedule:
+    - cron: '0 0 * * *'  # Runs daily at 00:00 UTC
 
 # Automatically stop old builds on the same branch/PR
 concurrency:
@@ -23,8 +27,12 @@ jobs:
         uses: prefix-dev/setup-pixi@ba3bb36eb2066252b2363392b7739741bb777659
       - name: Install repository
         run: pixi run postinstall
-      - name: Run Array API tests
+      - name: Run Array API tests (Scheduled)
+        if: ${{ github.event_name == 'schedule' }}
         run: pixi run arrayapitests
+      - name: Run Array API tests (Push)
+        if: ${{ github.event_name == 'push' }}
+        run: pixi run arrayapitests --max-examples 16 --hypothesis-seed=0
       - name: Upload Array API tests report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -3,7 +3,7 @@ name: Array API coverage tests
 on:
   push: # Run on all branches
   schedule:
-    - cron: "*/5 * * * *" # Runs daily at 00:00 UTC
+    - cron: "0 8 * * *" # Runs daily at 00:00 UTC
 
 # Automatically stop old builds on the same branch/PR
 concurrency:
@@ -28,7 +28,7 @@ jobs:
       - name: Install repository
         run: pixi run postinstall
       - name: Run Array API tests (Scheduled)
-        if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/main' }}
         run: pixi run arrayapitests
       - name: Run Array API tests (Push)
         if: ${{ github.event_name == 'push' }}

--- a/README.md
+++ b/README.md
@@ -104,11 +104,5 @@ Summary(1119 total):
 Run the tests with:
 
 ```bash
-pixi run arrayapitests
-```
-
-Or for a faster feedback cycle, with a fixed seed:
-
-```bash
 pixi run arrayapitests --max-examples 16 --hypothesis-seed=0
 ```

--- a/README.md
+++ b/README.md
@@ -106,3 +106,9 @@ Run the tests with:
 ```bash
 pixi run arrayapitests
 ```
+
+Or for a faster feedback cycle, with a fixed seed:
+
+```bash
+pixi run arrayapitests --max-examples 16 --hypothesis-seed=0
+```

--- a/pixi.toml
+++ b/pixi.toml
@@ -49,7 +49,7 @@ test = "pytest"
 test-coverage = "pytest --cov=ndonnx --cov-report=xml --cov-report=term-missing"
 
 [feature.test.tasks.arrayapitests]
-cmd = "pytest --max-examples 16 api-coverage-tests/array_api_tests/  -v -rfX --json-report --json-report-file=api-coverage-tests.json -n auto --disable-deadline --disable-extension linalg --skips-file=skips.txt --xfails-file=xfails.txt --hypothesis-seed=0"
+cmd = "pytest api-coverage-tests/array_api_tests/ -v -rfX --json-report --json-report-file=api-coverage-tests.json -n auto --disable-deadline --disable-extension linalg --skips-file=skips.txt --xfails-file=xfails.txt"
 [feature.test.tasks.arrayapitests.env]
 ARRAY_API_TESTS_MODULE = "ndonnx"
 ARRAY_API_TESTS_VERSION = "2023.12"


### PR DESCRIPTION
This test enables nightly tests on the Array API, which tests using the "max-examples" set to the default and a non-constant seed. 

The time the action runs is taken from the [last scheduled job](https://github.com/Quantco/ndonnx/actions/runs/10072907802/workflow). 