### PR TITLE
Zero size matmul mitigation

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1067,3 +1067,26 @@ def test_repeat_raises(a, repeats, axis):
 def test_getitem_bool_raises(x, index):
     with pytest.raises(IndexError):
         x[index]
+
+
+@pytest.mark.parametrize(
+    "x, y",
+    [
+        (
+            ndx.asarray([], dtype=ndx.uint8),
+            ndx.asarray([], dtype=ndx.uint8),
+        ),
+        (
+            ndx.asarray([], dtype=ndx.float32),
+            ndx.asarray([], dtype=ndx.int16),
+        ),
+        (
+            ndx.asarray([1, 2, 3], dtype=ndx.uint8),
+            ndx.asarray([1, 2, 3], dtype=ndx.float32),
+        ),
+    ],
+)
+def test_matmul_zero_dims(x, y):
+    ndx_result = x @ y
+    np_result = x.to_numpy() @ y.to_numpy()
+    assert_array_equal(ndx_result.to_numpy(), np_result)


### PR DESCRIPTION
Addresses undefined behavior in onnxruntime as exhibited in https://github.com/Quantco/ndonnx/actions/runs/12972746658/job/36180534245#step:5:3324. We should address this upstream.