### PR TITLE
Remove @neNasko1 temporarily

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @adityagoel4512 @cbourjau @neNasko1
+* @adityagoel4512 @cbourjau

--- a/.github/workflows/array-api.yml
+++ b/.github/workflows/array-api.yml
@@ -63,7 +63,7 @@ jobs:
                   repo: context.repo.repo,
                   title: "Weekly run failure: Array API coverage",
                   body: "The weekly run of the Array API test suite failed. See https://github.com/Quantco/ndonnx/actions/runs/${{ github.run_id }} for details.",
-                  assignees: ["adityagoel4512", "cbourjau", "neNasko1"],
+                  assignees: ["adityagoel4512", "cbourjau"],
                   labels: ["[bot] Weekly run"]
                 })
               }


### PR DESCRIPTION
I am removing @neNasko1 as a code owner temporarily due to some org/repo level settings that will need to be re-configured. Currently, this affects our weekly Array API tests: https://github.com/Quantco/ndonnx/actions/runs/12972746658/job/36180534245#step:8:28.