### PR TITLE
Address xfails and mislabelled kind

### DIFF
--- a/ndonnx/__init__.py
+++ b/ndonnx/__init__.py
@@ -167,6 +167,7 @@ from ._constants import (
     inf,
     nan,
     pi,
+    newaxis,
 )
 
 try:
@@ -185,6 +186,7 @@ __all__ = [
     "inf",
     "nan",
     "pi",
+    "newaxis",
     "arange",
     "asarray",
     "empty",

--- a/ndonnx/_data_types/aliases.py
+++ b/ndonnx/_data_types/aliases.py
@@ -89,16 +89,16 @@ def canonical_name(dtype: CoreType) -> str:
 
 _kinds = {
     bool: ("bool",),
-    int8: ("signed integer", "integer", "numeric"),
-    int16: ("signed integer", "integer", "numeric"),
-    int32: ("signed integer", "integer", "numeric"),
-    int64: ("signed integer", "integer", "numeric"),
-    uint8: ("unsigned integer", "integer", "numeric"),
-    uint16: ("unsigned integer", "integer", "numeric"),
-    uint32: ("unsigned integer", "integer", "numeric"),
-    uint64: ("unsigned integer", "integer", "numeric"),
-    float32: ("floating", "numeric"),
-    float64: ("floating", "numeric"),
+    int8: ("signed integer", "integral", "numeric"),
+    int16: ("signed integer", "integral", "numeric"),
+    int32: ("signed integer", "integral", "numeric"),
+    int64: ("signed integer", "integral", "numeric"),
+    uint8: ("unsigned integer", "integral", "numeric"),
+    uint16: ("unsigned integer", "integral", "numeric"),
+    uint32: ("unsigned integer", "integral", "numeric"),
+    uint64: ("unsigned integer", "integral", "numeric"),
+    float32: ("real floating", "numeric"),
+    float64: ("real floating", "numeric"),
 }
 
 

--- a/xfails.txt
+++ b/xfails.txt
@@ -2,11 +2,7 @@
 array_api_tests/test_searching_functions.py::test_argmin
 array_api_tests/test_searching_functions.py::test_argmax
 
-array_api_tests/test_constants.py::test_newaxis
-array_api_tests/test_creation_functions.py::test_eye
 array_api_tests/test_creation_functions.py::test_meshgrid
-array_api_tests/test_data_type_functions.py::test_can_cast
-array_api_tests/test_data_type_functions.py::test_isdtype
 array_api_tests/test_has_names.py::test_has_names[array_method-__complex__]
 array_api_tests/test_has_names.py::test_has_names[array_method-__dlpack__]
 array_api_tests/test_has_names.py::test_has_names[array_method-__dlpack_device__]

--- a/xfails.txt
+++ b/xfails.txt
@@ -2,6 +2,7 @@
 array_api_tests/test_searching_functions.py::test_argmin
 array_api_tests/test_searching_functions.py::test_argmax
 
+array_api_tests/test_creation_functions.py::test_eye
 array_api_tests/test_creation_functions.py::test_meshgrid
 array_api_tests/test_has_names.py::test_has_names[array_method-__complex__]
 array_api_tests/test_has_names.py::test_has_names[array_method-__dlpack__]
@@ -84,7 +85,6 @@ array_api_tests/test_operators_and_elementwise_functions.py::test_sqrt
 array_api_tests/test_operators_and_elementwise_functions.py::test_tan
 array_api_tests/test_searching_functions.py::test_nonzero_zerodim_error
 array_api_tests/test_searching_functions.py::test_searchsorted
-array_api_tests/test_searching_functions.py::test_where
 array_api_tests/test_set_functions.py::test_unique_all
 array_api_tests/test_set_functions.py::test_unique_counts
 array_api_tests/test_set_functions.py::test_unique_inverse


### PR DESCRIPTION
I mislabelled the integral kind in https://github.com/Quantco/ndonnx/commit/039264da5587edc5a65ebc6ac2f7f0d0f19176de. It wasn't caught since we skipped a relevant test from upstream.