### PR TITLE
Add tests for schema stability

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+# Copyright (c) QuantCo 2023-2025
+# SPDX-License-Identifier: BSD-3-Clause
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--update-schema-snapshots",
+        action="store_true",
+        help="Update schema snapshots for stability tests. This should only be used in extraordinary and well understood circumstances.",
+    )
+
+
+@pytest.fixture
+def update_schema_snapshots(request):
+    return request.config.getoption("--update-schema-snapshots")

--- a/tests/schemas/bool.json
+++ b/tests/schemas/bool.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "Boolean",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "Boolean",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/float32.json
+++ b/tests/schemas/float32.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "Float32",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "Float32",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/float64.json
+++ b/tests/schemas/float64.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "Float64",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "Float64",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/int16.json
+++ b/tests/schemas/int16.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "Int16",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "Int16",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/int32.json
+++ b/tests/schemas/int32.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "Int32",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "Int32",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/int64.json
+++ b/tests/schemas/int64.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "Int64",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "Int64",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/int8.json
+++ b/tests/schemas/int8.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "Int8",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "Int8",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/nbool.json
+++ b/tests/schemas/nbool.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "NBoolean",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "NBoolean",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/nfloat32.json
+++ b/tests/schemas/nfloat32.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "NFloat32",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "NFloat32",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/nfloat64.json
+++ b/tests/schemas/nfloat64.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "NFloat64",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "NFloat64",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/nint16.json
+++ b/tests/schemas/nint16.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "NInt16",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "NInt16",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/nint32.json
+++ b/tests/schemas/nint32.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "NInt32",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "NInt32",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/nint64.json
+++ b/tests/schemas/nint64.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "NInt64",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "NInt64",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/nint8.json
+++ b/tests/schemas/nint8.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "NInt8",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "NInt8",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/nuint16.json
+++ b/tests/schemas/nuint16.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "NUInt16",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "NUInt16",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/nuint32.json
+++ b/tests/schemas/nuint32.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "NUInt32",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "NUInt32",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/nuint64.json
+++ b/tests/schemas/nuint64.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "NUInt64",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "NUInt64",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/nuint8.json
+++ b/tests/schemas/nuint8.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "NUInt8",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "NUInt8",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/nutf8.json
+++ b/tests/schemas/nutf8.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "NUtf8",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "NUtf8",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/uint16.json
+++ b/tests/schemas/uint16.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "UInt16",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "UInt16",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/uint32.json
+++ b/tests/schemas/uint32.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "UInt32",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "UInt32",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/uint64.json
+++ b/tests/schemas/uint64.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "UInt64",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "UInt64",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/uint8.json
+++ b/tests/schemas/uint8.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "UInt8",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "UInt8",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/schemas/utf8.json
+++ b/tests/schemas/utf8.json
@@ -1,0 +1,17 @@
+{
+    "input_schema": {
+        "a": {
+            "author": "ndonnx",
+            "type_name": "Utf8",
+            "meta": null
+        }
+    },
+    "output_schema": {
+        "b": {
+            "author": "ndonnx",
+            "type_name": "Utf8",
+            "meta": null
+        }
+    },
+    "version": 1
+}

--- a/tests/test_build_utils.py
+++ b/tests/test_build_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import json
@@ -107,7 +107,7 @@ def test_no_namemangling_for_standard_types(dtype):
         ndx.utf8,
     ],
 )
-def test_schema_against_snapshots(dtype):
+def test_schema_against_snapshots(dtype, update_schema_snapshots):
     # We must not break backwards compatibility. We test every type we
     # support that it keeps producing the same schema.
 
@@ -128,12 +128,7 @@ def test_schema_against_snapshots(dtype):
         dtype = str(dtype).lower()
     fname = Path(__file__).parent / f"schemas/{dtype}.json"
 
-    # Only set to `True` temporarily if the schemas need to be
-    # re-generated. A schema, once stabilized, must never
-    # change. However, this flag may come in handy if we add new data
-    # types for instance.
-    update = False
-    if update:
+    if update_schema_snapshots:
         # Ensure a stable order
         metadata = sorted(mp.metadata_props, key=lambda el: el.key)
         with open(fname, "w+") as f:

--- a/tests/test_build_utils.py
+++ b/tests/test_build_utils.py
@@ -1,9 +1,13 @@
 # Copyright (c) QuantCo 2023-2024
 # SPDX-License-Identifier: BSD-3-Clause
 
+import json
+from pathlib import Path
+
 import pytest
 
 import ndonnx as ndx
+from ndonnx import _data_types as dtypes
 
 
 @pytest.mark.parametrize(
@@ -38,3 +42,112 @@ def test_input_output_name_backwards_compatibility(dtype):
         "output_values",
         "output_null",
     ]
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ndx.int8,
+        ndx.int16,
+        ndx.int32,
+        ndx.int64,
+        ndx.float32,
+        ndx.float64,
+        ndx.utf8,
+        ndx.bool,
+        ndx.uint8,
+        ndx.uint16,
+        ndx.uint32,
+        ndx.uint64,
+    ],
+)
+def test_no_namemangling_for_standard_types(dtype):
+    a = ndx.array(shape=("N",), dtype=dtype)
+    model_proto = ndx.build({"input": a}, {"output": a})
+    assert [node.name for node in model_proto.graph.input] == ["input"]
+    assert [node.name for node in model_proto.graph.output] == ["output"]
+    a = ndx.array(shape=("N",), dtype=dtypes.into_nullable(dtype))
+    model_proto = ndx.build({"input": a}, {"output": a})
+    assert {node.name for node in model_proto.graph.input} == {
+        "input_values",
+        "input_null",
+    }
+    assert {node.name for node in model_proto.graph.output} == {
+        "output_values",
+        "output_null",
+    }
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        ndx.bool,
+        ndx.float32,
+        ndx.float64,
+        ndx.int16,
+        ndx.int32,
+        ndx.int64,
+        ndx.int8,
+        ndx.nbool,
+        ndx.nfloat32,
+        ndx.nfloat64,
+        ndx.nint16,
+        ndx.nint32,
+        ndx.nint64,
+        ndx.nint8,
+        ndx.nuint16,
+        ndx.nuint32,
+        ndx.nuint64,
+        ndx.nuint8,
+        ndx.nutf8,
+        ndx.uint16,
+        ndx.uint32,
+        ndx.uint64,
+        ndx.uint8,
+        ndx.utf8,
+    ],
+)
+def test_schema_against_snapshots(dtype):
+    # We must not break backwards compatibility. We test every type we
+    # support that it keeps producing the same schema.
+
+    a = ndx.array(shape=("N",), dtype=dtype)
+    b = a[0]  # make the build non-trivial
+
+    mp = ndx.build({"a": a}, {"b": b})
+
+    # These files should not be update automatically!
+    # File names follow NumPy's __str__ semantics for primitive data
+    # types and generally uses lower case. ndonnx does not have the
+    # same __str__ semantics today.
+    if dtype == ndx.bool:
+        dtype = "bool"
+    elif dtype == ndx.nbool:
+        dtype = "nbool"
+    else:
+        dtype = str(dtype).lower()
+    fname = Path(__file__).parent / f"schemas/{dtype}.json"
+
+    # Only set to `True` temporarily if the schemas need to be
+    # re-generated. A schema, once stabilized, must never
+    # change. However, this flag may come in handy if we add new data
+    # types for instance.
+    update = False
+    if update:
+        # Ensure a stable order
+        metadata = sorted(mp.metadata_props, key=lambda el: el.key)
+        with open(fname, "w+") as f:
+            json.dump(
+                json.loads({el.key: el.value for el in metadata}["ndonnx_schema"]),
+                f,
+                indent=4,
+            )
+            f.write("\n")  # Avoid pre-commit complaint about missing new lines
+
+    with open(fname) as f:
+        expected_schemas = json.load(f)
+    candidate_schemas = json.loads(
+        {el.key: el.value for el in mp.metadata_props}["ndonnx_schema"]
+    )
+
+    assert expected_schemas == candidate_schemas


### PR DESCRIPTION
This test is back-ported from #110. It should be its own PR based on the current `main` since it ought to ensure that we did not break the current schemas.