### PR TITLE
Don't call PyPI publishing action twice in the same job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,9 @@ jobs:
           name: artifact
           path: dist/*
 
-  release:
+  # Calling the publish-action twice in the same job is not supported:
+  # https://github.com/pypa/gh-action-pypi-publish/issues/352
+  release-TestPyPi:
     name: Publish package
     if: startsWith(github.ref, 'refs/tags/')
     needs: [build]
@@ -44,5 +46,18 @@ jobs:
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           repository-url: https://test.pypi.org/legacy/
+  release-PyPi:
+    name: Publish package
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: artifact
+          path: dist
       - name: Publish package on PyPi
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@
 Changelog
 =========
 
+0.10.1 (2025-04-01)
+-------------------
+
+Technical release to address a PyPI publishing issue.
+
+
 
 0.10.0 (2025-04-01)
 -------------------


### PR DESCRIPTION
Apparently calling the publishing action twice in the same job is not supported (related [issue](https://github.com/pypa/gh-action-pypi-publish/issues/352)). This caused the publishing of the 0.10 release to fail.