### PR TITLE
Fix modulo operator for floating points when second arg is negative

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,13 @@
 Changelog
 =========
 
-0.12.0 (unreleased)
+0.12.0 (2025-05-15)
 -------------------
+
+**Bug fix**
+
+- The modulo operator (``%``) now correctly follows Python's semantics if the second argument is negative.
+
 
 **New features**
 

--- a/tests/test_elementwise.py
+++ b/tests/test_elementwise.py
@@ -1,0 +1,20 @@
+# Copyright (c) QuantCo 2023-2024
+# SPDX-License-Identifier: BSD-3-Clause
+
+import numpy as np
+import pytest
+
+import ndonnx as ndx
+
+
+@pytest.mark.parametrize("x", [-3.0, 3.0])
+@pytest.mark.parametrize("y", [-2.0, 2.0])
+def test_floating_point_modulo_follows_python(x, y):
+    def do(npx):
+        x_arr = npx.asarray(x, dtype=npx.float64)
+        y_arr = npx.asarray(y, dtype=npx.float64)
+
+        return x_arr % y_arr
+
+    np.testing.assert_array_equal(do(ndx).unwrap_numpy(), do(np))
+    assert do(ndx).unwrap_numpy() == x % y


### PR DESCRIPTION
The provided test case fails on the current release, but was already fixed in #120 .