### PR TITLE
Extend time unit support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changelog
 - The :class:`ndonnx.TimeDelta64DType` and :class:`ndonnx.DateTime64DType` gained support for milli and microseconds as units.
 - :func:`ndonnx.where` now promotes time units between the two branches.
 - Addition, multiplication, division, and subtraction between arrays with timedelta or datetime data types now support promotion between time units.
+- Comparison operations between arrays with timedelta or datetime data types now support promotion between time units.
 
 
 0.12.0 (2025-05-15)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,16 @@
 Changelog
 =========
 
+0.13.0 (2025-05-22)
+-------------------
+
+**New features**
+
+- The :class:`ndonnx.TimeDelta64DType` and :class:`ndonnx.DateTime64DType` gained support for milli and microseconds as units.
+- :func:`ndonnx.where` now promotes time units between the two branches.
+- Addition, multiplication, division, and subtraction between arrays with timedelta or datetime data types now support promotion between time units.
+
+
 0.12.0 (2025-05-15)
 -------------------
 


### PR DESCRIPTION
This PR adds promotion between time units for arithmetic, comparisons, and `ndonnx.where`. It further adds support for milli and microseconds. The semantics follow those of NumPy as usual and are tested in this regard.

Closes https://github.com/Quantco/ndonnx/issues/131.