### PR TITLE
Fix failing test case for 'where' with one scalar value

### DIFF
--- a/ndonnx/_typed_array/onnx.py
+++ b/ndonnx/_typed_array/onnx.py
@@ -970,6 +970,16 @@ class TyArray(TyArrayBase):
 
         return NotImplemented
 
+    def __ndx_rwhere__(
+        self, cond: TyArrayBool, x: TyArrayBase | PyScalar, /
+    ) -> TyArrayBase | NotImplementedType:
+        if isinstance(x, TyArray | PyScalar):
+            y, x = promote(self, x)
+            var = op.where(cond._var, x._var, y._var)
+            return type(x)(var)
+
+        return NotImplemented
+
 
 class TyArrayUtf8(TyArray):
     @property


### PR DESCRIPTION
This was discovered by running array-api-tests with more examples. I'll create a PR to increase the number of examples on CI, too.