### PR TITLE
Fix asarray for uint64 dtypes with very large integers

### DIFF
--- a/ndonnx/_typed_array/onnx.py
+++ b/ndonnx/_typed_array/onnx.py
@@ -116,7 +116,7 @@ class _OnnxDType(DType[TY_ARRAY_co]):
         elif isinstance(val, PyScalar | np.ndarray | np.generic):
             return const(val, dtype=self)
         elif isinstance(val, Sequence):
-            return self.__ndx_create__(np.asarray(val))
+            return self.__ndx_create__(np.asarray(val, dtype=self.unwrap_numpy()))
         elif isinstance(val, TyArrayBase):
             return val.copy().astype(self)
         return NotImplemented


### PR DESCRIPTION
Another simple fix based on an error I observed when running the array-api-tests suite with a much larger number of examples. This fixes instantiating arrays from very large Python integers when the user actually specified the data type as uint64.