### PR TITLE
Add missing ort_compat handling for reduce_max/reduce_min and fix changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,15 @@
 Changelog
 =========
 
-0.13.0 (2025-05-22)
+0.13.0 (unreleased)
 -------------------
+
+**Bug fixes**
+
+- Add missing onnxruntime workaround for uint32 inputs to ``ndonnx.min`` and ``ndonnx.max``.
+- Fix array instantiation with ``ndonnx.asarray`` and very large Python integers for ``uint64`` data types.
+- Fix passing an Python scalar as the second argument to ``ndonnx.where``.
+
 
 **New features**
 

--- a/ndonnx/_typed_array/ort_compat.py
+++ b/ndonnx/_typed_array/ort_compat.py
@@ -289,6 +289,7 @@ reduce_sum = partial(reduce_op, spox_op=op.reduce_sum, mapping=_mapping_reduce_s
 # tensor(int64)
 _mapping_reduce_max: _MappingDictType = {
     (np.int8, np.int16, np.uint8, np.uint16): np.int32,
+    (np.uint32,): np.int64,
     (np.uint64,): Warn(np.float64),
 }
 reduce_max = partial(reduce_op, spox_op=op.reduce_max, mapping=_mapping_reduce_max)
@@ -297,6 +298,7 @@ reduce_max = partial(reduce_op, spox_op=op.reduce_max, mapping=_mapping_reduce_m
 # tensor(int64), tensor(int8), tensor(uint8)
 _mapping_reduce_min: _MappingDictType = {
     (np.int16, np.uint16): np.int32,
+    (np.uint32,): np.int64,
     (np.uint32, np.uint64): Warn(np.float64),
 }
 reduce_min = partial(reduce_op, spox_op=op.reduce_min, mapping=_mapping_reduce_min)


### PR DESCRIPTION
This again showed up when running the array-api-test suite with many more examples. 