### PR TITLE
Fix __setitem__ for boolean masks on multidimensional arrays

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,11 +12,12 @@ Changelog
 
 **Bug fix**
 
-- Fix a bug in ``ndonnx.Array.__setitem__`` that occurred when all of the following applied:
+- Fix a bug in :meth:`ndonnx.Array.__setitem__` that occurred when all of the following applied:
   - An ``Ellipsis`` was part of the key
   - The ``Ellipsis`` expanded to at least one dimension
   - The ``Ellipsis`` was not the last element of the key
   - The assigned value was not a scalar or 1D array with length 1.
+- :meth:`ndonnx.Array.__setitem__` now correctly handles boolean masks for arrays of two or more dimensions.
 
 
 **New workarounds for missing onnxruntime implementations**

--- a/ndonnx/_typed_array/onnx.py
+++ b/ndonnx/_typed_array/onnx.py
@@ -540,27 +540,35 @@ class TyArray(TyArrayBase):
     def _setitem_boolmask(self, key: TyArrayBool, value: Self) -> None:
         if self.ndim < key.ndim:
             raise IndexError("provided boolean mask has higher rank than 'self'")
-        if self.ndim > key.ndim:
-            diff = self.ndim - key.ndim
-            # expand to rank of self
-            idx = [...] + diff * [None]
-            key = key[tuple(idx)]
-
         if value.ndim == 0:
             # We can be sure that we don't run into broadcasting
             # issues with a zero-sized value if the value is a
             # scalar. This allows us to use `where`.
+            if self.ndim > key.ndim:
+                diff = self.ndim - key.ndim
+                # expand to rank of self
+                idx = [...] + diff * [None]
+                key = key[tuple(idx)]
             self._var = op.where(key._var, value._var, self._var)
             return
+        elif value.ndim != 1:
+            # NumPy semantics
+            TypeError(
+                f"assignment value must be 0 or 1-dimensional for boolean indexing, got `{value.ndim}`"
+            )
 
-        int_keys = safe_cast(
-            TyArrayInt64,
-            const(1, int64).broadcast_to(key.dynamic_shape).cumulative_sum() - 1,
-        )[key]
-        arr = self.copy().reshape((-1,))
-        arr.put(int_keys, value.reshape((-1,)))
-        arr.reshape(self.dynamic_shape)
-        self._var = arr._var
+        # The following is essentially doing `self[ndx.nonzero(key)] = value`
+        non_zero = [el[..., None] for el in key.nonzero()]
+        indices_len_last_dim = len(non_zero)
+        indices = non_zero[0].concat(non_zero[1:], axis=-1)
+        update_target_shape = indices.dynamic_shape[:-1].concat(
+            [self.dynamic_shape[indices_len_last_dim:]], axis=0
+        )
+
+        # ScatterND does not support broadcasting the updates
+        updates = value.broadcast_to(update_target_shape)
+
+        self._var = op.scatter_nd(self._var, indices._var, updates._var)
 
     def _setitem_int_array(self, key: TyArrayInt64, value: Self) -> None:
         # The last dim of shape must be statically known (i.e. the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,4 +102,4 @@ filterwarnings = [
 ]
 
 [tool.typos.default]
-extend-ignore-identifiers-re = ["scatter_nd", "arange", "gather_nd"]
+extend-ignore-identifiers-re = ["scatter_nd", "arange", "gather_nd", "ScatterND"]

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -166,6 +166,36 @@ def test_setitem_boolean_mask_value_is_array():
     np.testing.assert_array_equal(do(np), do(ndx).unwrap_numpy())
 
 
+@pytest.mark.parametrize(
+    "update",
+    [
+        # Assign scalar value
+        11,
+        # Broadcastable on both dimensions
+        [11],
+        # Broadcast on second dimension
+        [[11], [44]],
+        # Specify all elements instead of broadcasting
+        [[11, 22, 33], [44, 55, 66]],
+    ],
+)
+def test_setitem_on_2d_array_with_boolean_mask(update):
+    # Numpy does not allow using boo_mask.ndim >1 in __setitem__
+    def do(npx):
+        np_arr = np.arange(0, 9, dtype=np.int64).reshape(
+            (
+                3,
+                3,
+            )
+        )
+        arr = npx.asarray(np_arr)
+        key_arr = npx.asarray([True, False, True])
+        arr[key_arr] = npx.asarray(update)
+        return arr
+
+    np.testing.assert_array_equal(do(np), do(ndx).unwrap_numpy())
+
+
 def test_scalar_array_key():
     np_arr = np.asarray([1, 2, 3], dtype=np.int64)
     np_key = np.asarray(1, dtype=np.int64)


### PR DESCRIPTION
The current release of ndonnx raises an exception if a 1D boolean mask is used in in the `__setitem__` method of an array of 2 or more dimensions. This PR implements that functionality and tests it against NumPy.