### PR TITLE
Fix rank dynamic size

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,13 +10,14 @@ Changelog
 0.14.0 (unreleased)
 -------------------
 
-**Bug fix**
+**Bug fixes**
 
 - Fix a bug in ``ndonnx.Array.__setitem__`` that occurred when all of the following applied:
   - An ``Ellipsis`` was part of the key
   - The ``Ellipsis`` expanded to at least one dimension
   - The ``Ellipsis`` was not the last element of the key
   - The assigned value was not a scalar or 1D array with length 1.
+- :meth:`ndonnx.Array.dynamic_shape` now returns a rank-0 array for all input ranks.
 
 
 **New workarounds for missing onnxruntime implementations**

--- a/ndonnx/_array.py
+++ b/ndonnx/_array.py
@@ -120,7 +120,7 @@ class Array:
         if self.ndim == 0:
             Array._from_tyarray(onnx.const(1, dtype=onnx.int64))
         if self.ndim == 1:
-            return self.dynamic_shape
+            return self.dynamic_shape[0]
 
         return Array._from_tyarray(self.dynamic_shape._tyarray.prod())
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1030,3 +1030,10 @@ def test_argmaxmin(func, x, keepdims):
         ndx.asarray(x), keepdims=keepdims
     ).unwrap_numpy()
     assert_array_equal(np_result, ndx_result)
+
+
+@pytest.mark.parametrize("val", [[], 1, [1], [1, 1], [[1, 2], [3, 4]]])
+def test_dynamic_size(val):
+    expected = np.asarray(np.asarray(val).size)
+    candidate = ndx.asarray(val).dynamic_size
+    np.testing.assert_array_equal(candidate.unwrap_numpy(), expected, strict=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from sys import platform
+import platform
 
 import numpy as np
 import pytest
@@ -1041,5 +1041,5 @@ def test_dynamic_size(val):
     np.testing.assert_array_equal(
         candidate.unwrap_numpy(),
         expected,
-        strict=np.__version__ < "2" and platform.startswith("win"),
+        strict=not (np.__version__ < "2" and platform.system() == "Windows"),
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from sys import platform
+
 import numpy as np
 import pytest
 import spox.opset.ai.onnx.v19 as op
@@ -1034,6 +1036,10 @@ def test_argmaxmin(func, x, keepdims):
 
 @pytest.mark.parametrize("val", [[], 1, [1], [1, 1], [[1, 2], [3, 4]]])
 def test_dynamic_size(val):
-    expected = np.asarray(np.asarray(val).size)
+    expected = np.asarray(val).size
     candidate = ndx.asarray(val).dynamic_size
-    np.testing.assert_array_equal(candidate.unwrap_numpy(), expected, strict=True)
+    np.testing.assert_array_equal(
+        candidate.unwrap_numpy(),
+        expected,
+        strict=np.__version__ < "2" and platform.startswith("win"),
+    )


### PR DESCRIPTION
Calling `Array.dynamic_size` should return a scalar in all cases. However, the current release of ndonnx returns a 1D array (with a single element) if `dynamic_size` is called on 1D input.