### PR TITLE
Enable using `slice`s in setitem without value propagation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changelog
   - The ``Ellipsis`` expanded to at least one dimension
   - The ``Ellipsis`` was not the last element of the key
   - The assigned value was not a scalar or 1D array with length 1.
+- Using `slice` objects in the :meth:`ndonnx.Array.__setitem__` no longer require value propagation.
 
 
 **New workarounds for missing onnxruntime implementations**

--- a/ndonnx/_typed_array/onnx.py
+++ b/ndonnx/_typed_array/onnx.py
@@ -2674,8 +2674,8 @@ def _get_indices(
     if s.stop is None:
         stop = lower if step_is_negative else upper
     elif isinstance(s.stop, int):
+        stop_is_neg = s.stop < 0
         stop = const(s.stop, dtype=int64)
-        stop_is_neg = stop < 0
         if stop_is_neg:
             stop = maximum(stop + length_, lower)
         else:


### PR DESCRIPTION
This was an oversight in the existing implementation. The produced graphs are the same either way.