### PR TITLE
Fix error message for fancy-slicing in setitem with int-arrays

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changelog
   - The ``Ellipsis`` expanded to at least one dimension
   - The ``Ellipsis`` was not the last element of the key
   - The assigned value was not a scalar or 1D array with length 1.
+- Using `slice` objects in the :meth:`ndonnx.Array.__setitem__` no longer require value propagation.
 
 
 **New workarounds for missing onnxruntime implementations**

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changelog
   - The ``Ellipsis`` expanded to at least one dimension
   - The ``Ellipsis`` was not the last element of the key
   - The assigned value was not a scalar or 1D array with length 1.
+- The error message of the ``IndexingError`` raise by :meth:`ndonnx.Array.__setitem__` when providing a tuple-key containing int64-arrays is now accurate.
 - Using `slice` objects in the :meth:`ndonnx.Array.__setitem__` no longer require value propagation.
 
 

--- a/ndonnx/_array.py
+++ b/ndonnx/_array.py
@@ -237,7 +237,7 @@ class Array:
         )
 
     def __getitem__(self, key: GetItemKey, /) -> Array:
-        idx = _normalize_arrays_in_key(key)
+        idx = _normalize_arrays_in_getitem_key(key)
         data = self._tyarray[idx]
         return type(self)._from_tyarray(data)
 
@@ -253,15 +253,9 @@ class Array:
             if isinstance(value, Array)
             else tyfuncs.astyarray(value, dtype=self.dtype)
         )
+        idx = _normalize_arrays_in_setitem_key(key)
 
-        if isinstance(key, Array):
-            if not isinstance(key._tyarray, onnx.TyArrayInteger | onnx.TyArrayBool):
-                raise TypeError(
-                    f"indexing array must have integer or boolean data type; found `{key.dtype}`"
-                )
-            self._tyarray[key._tyarray] = updates
-        else:
-            self._tyarray[key] = updates
+        self._tyarray[idx] = updates
 
     def __bool__(self, /) -> bool:
         return bool(self.unwrap_numpy())
@@ -388,24 +382,44 @@ def _apply_op(
     return NotImplemented
 
 
-def _normalize_arrays_in_key(key: GetItemKey) -> onnx.GetitemIndex:
+def _normalize_arrays_in_getitem_key(key: GetItemKey) -> onnx.GetitemIndex:
     if isinstance(key, Array):
         if isinstance(key._tyarray.dtype, onnx.Bool):
             return key._tyarray.astype(onnx.bool_)
 
     if isinstance(key, int | slice | EllipsisType | Array | None):
-        return _normalize_key_item(key)
+        return _normalize_getitem_key_item(key)
 
     if isinstance(key, tuple):
-        return tuple(_normalize_key_item(el) for el in key)
+        return tuple(_normalize_getitem_key_item(el) for el in key)
 
     raise IndexError(f"unexpected key type: `{type(key)}`")
 
 
-def _normalize_key_item(
+def _normalize_arrays_in_setitem_key(key: SetitemKey) -> onnx.SetitemIndex:
+    if isinstance(key, Array):
+        if isinstance(key._tyarray.dtype, onnx.Bool):
+            return key._tyarray.astype(onnx.bool_)
+
+    if isinstance(key, int | slice | EllipsisType | Array | None):
+        return _normalize_setitem_key_item(key)
+
+    if isinstance(key, tuple):
+        return tuple(_normalize_setitem_key_item(el) for el in key)
+
+    raise IndexError(f"unexpected key type: `{type(key)}`")
+
+
+def _normalize_getitem_key_item(
     item: int | slice | EllipsisType | Array | None,
 ) -> int | slice | EllipsisType | onnx.TyArrayInt64 | None:
-    if isinstance(item, int | EllipsisType | None):
+    return None if item is None else _normalize_setitem_key_item(item)
+
+
+def _normalize_setitem_key_item(
+    item: int | slice | EllipsisType | Array,
+) -> int | slice | EllipsisType | onnx.TyArrayInt64:
+    if isinstance(item, int | EllipsisType):
         return item
 
     if isinstance(item, Array):

--- a/ndonnx/_typed_array/onnx.py
+++ b/ndonnx/_typed_array/onnx.py
@@ -508,7 +508,11 @@ class TyArray(TyArrayBase):
 
         if isinstance(key, TyArrayBool):
             return self._setitem_boolmask(key, value)
-        elif isinstance(key, TyArrayInteger):
+        elif (
+            isinstance(key, TyArrayInteger)
+            or isinstance(key, tuple)
+            and any(isinstance(item, TyArrayInteger) for item in key)
+        ):
             raise IndexError("'__setitem__' with integer arrays is not supported")
         elif isinstance(key, tuple):
             length_without_ellipsis = len([el for el in key if el != ...])

--- a/ndonnx/_typed_array/onnx.py
+++ b/ndonnx/_typed_array/onnx.py
@@ -2674,8 +2674,8 @@ def _get_indices(
     if s.stop is None:
         stop = lower if step_is_negative else upper
     elif isinstance(s.stop, int):
+        stop_is_neg = s.stop < 0
         stop = const(s.stop, dtype=int64)
-        stop_is_neg = stop < 0
         if stop_is_neg:
             stop = maximum(stop + length_, lower)
         else:

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -200,3 +200,17 @@ def test_integer_array_indexing():
         return arr[key]
 
     np.testing.assert_array_equal(do(ndx).unwrap_numpy(), do(np), strict=True)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ndx.asarray([1]),
+        (ndx.asarray([1]),),
+    ],
+)
+def test_setitem_fancy_indexing_integer_array_raises(key):
+    arr = ndx.asarray([1.0, 1.0])
+
+    with pytest.raises(IndexError, match="__setitem__"):
+        arr[key] = 10.0


### PR DESCRIPTION
Rather than being explicitly disallowed previously we failed with an error erroneously referring to an issue with an `Ellipsis` object in the provided key. Fixing this required some refactoring around the index validation.