### PR TITLE
Add ort compat sign minimum maximum

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ Changelog
 
 - :func:`ndx.any` and :func:`ndx.all` now correctly propagate values even if the input is zero-sized.
 - :func:`ndonnx.arange` now follows NumPy's semantics for extremely large start, stop, and step values.
-- :func:`ndonnx.min` and :func:`ndonnx.max` now produce correct results for very large values in int64 arrays.
+- :func:`ndonnx.min`, :func:`ndonnx.max`, :func:`ndonnx.minimum`, :func:`ndonnx.maximum`, and :func:`ndonnx.clip` now produce correct results for very large values in int64 arrays.
 
 
 0.13.0 (2025-05-27)


### PR DESCRIPTION
The `Sign`, `Min`, `Max` and `Clip` operators have a rather strange bug in onnxruntime on Linux and Windows (or `x86_64`). I believe it might be due to some specialized code path in Eigen, but have not been able to get to the bottom of it yet. In the mean time, we should avoid these operators for the affected data type (i.e. int64). 

This was another issue surfaced by the array-api-tests suite. The fixes in this PR should finally get us to a place where the array-api-tests run through on all platform even when running with a large number of examples (~1000) as proposed in #145.