### PR TITLE
Correctly dispatch to call ndonnx.Array.__r*__ methods when the first operand is a NumPy array

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changelog
 - The error message of the ``IndexingError`` raise by :meth:`ndonnx.Array.__setitem__` when providing a tuple-key containing int64-arrays is now accurate.
 - Using `slice` objects in the :meth:`ndonnx.Array.__setitem__` no longer require value propagation.
 - :meth:`ndonnx.Array.__setitem__` now correctly handles boolean masks for arrays of two or more dimensions.
+- Operations between NumPy and ndonnx arrays now correctly call the reverse dunder methods such as :meth:`ndonnx.Array.__radd__` where appropriate.
 
 **New workarounds for missing onnxruntime implementations**
 

--- a/ndonnx/_array.py
+++ b/ndonnx/_array.py
@@ -48,6 +48,16 @@ class Array:
 
     _tyarray: TyArrayBase
 
+    # `__array_priority__` governs which operand is first called in
+    # operations involving a NumPy array/generic and a custom class
+    # (like this one). If not set, the first operand is always called
+    # first. This is problematic since NumPy does not directly return
+    # NotImplemented if called with an ndonnx.Array object. Setting
+    # this priority higher than that of a NumPy array (i.e. 0) ensures
+    # that a situation such as `np.ndarray + ndx.Array` will first
+    # call `ndx.Array.__radd__`.
+    __array_priority__ = 1
+
     def __init__(self, *args, **kwargs) -> None:
         raise TypeError(
             "'Array' cannot be instantiated directly. Use the 'ndonnx.array' or 'ndonnx.asarray' functions instead"

--- a/tests/test_interaction_numpy.py
+++ b/tests/test_interaction_numpy.py
@@ -1,0 +1,16 @@
+# Copyright (c) QuantCo 2023-2025
+# SPDX-License-Identifier: BSD-3-Clause
+
+import numpy as np
+
+import ndonnx as ndx
+
+
+def test_numpy_array_ndx_array_reverse_dunder_called_correctly():
+    np_arr = np.asarray([1, 2], dtype=np.int32)
+    np_arr_2 = np.asarray([3, 4], dtype=np.int32)
+
+    candidate = np_arr + ndx.asarray(np_arr_2)
+    expected = np_arr + np_arr_2
+
+    np.testing.assert_array_equal(candidate.unwrap_numpy(), expected, strict=True)


### PR DESCRIPTION
NumPy attempts some shenanigas to make operations with non-NumPy arrays work instead of just dispatching to the other objects `__r*__` methods. The recommended way to fix this is to set the [`__array_priority__`](https://numpy.org/doc/stable/user/c-info.beyond-basics.html#the-array-priority-attribute) member such that NumPy immediately dispatches to the `ndonnx.Array` methods.