### PR TITLE
Improve stack level shown in various warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Changelog
 =========
 
+0.14.1 (unreleased)
+-------------------
+
+**Other changes**
+
+- Improve stacklevel presented of various deprecation warnings.
+
+
 0.14.0 (2025-07-21)
 -------------------
 

--- a/ndonnx/__init__.py
+++ b/ndonnx/__init__.py
@@ -405,7 +405,11 @@ def __getattr__(name: str):
     )
 
     def _warn_use_instead(old: str, new: str):
-        warn(f"'{old}' is deprecated in favor of '{new}'", DeprecationWarning)
+        warn(
+            f"'{old}' is deprecated in favor of '{new}'",
+            DeprecationWarning,
+            stacklevel=3,
+        )
 
     superseded = {
         "additional": ("ndonnx.extensions", extensions),

--- a/ndonnx/_array.py
+++ b/ndonnx/_array.py
@@ -227,6 +227,7 @@ class Array:
         warn(
             "'Array.null' is deprecated in favor of 'ndonnx.extensions.get_mask'",
             DeprecationWarning,
+            stacklevel=2,
         )
         return get_mask(self)
 
@@ -235,6 +236,7 @@ class Array:
         warn(
             "'Array.values' is deprecated in favor of 'ndonnx.extensions.get_data'",
             DeprecationWarning,
+            stacklevel=2,
         )
 
         if isinstance(self._tyarray, TyMaArray):
@@ -254,6 +256,7 @@ class Array:
         warn(
             "'Array.to_numpy' is deprecated in favor of 'Array.unwrap_numpy'",
             DeprecationWarning,
+            stacklevel=2,
         )
         try:
             return self.unwrap_numpy()
@@ -269,6 +272,7 @@ class Array:
         warn(
             "'Array.spox_var' is deprecated in favor of 'Array.disassemble' or 'Array.unwrap_spox'",
             DeprecationWarning,
+            stacklevel=2,
         )
         return self.unwrap_spox()
 

--- a/ndonnx/_deprecated.py
+++ b/ndonnx/_deprecated.py
@@ -4,18 +4,21 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TypeAlias
 from warnings import warn
+
+from spox import Var
 
 import ndonnx as ndx
 from ndonnx import _typed_array as tydx
 
-if TYPE_CHECKING:
-    from spox import Var
-
 
 def from_spox_var(var: Var) -> ndx.Array:
-    warn("'from_spox_var' is deprecated in favor of 'asarray'")
+    warn(
+        "'from_spox_var' is deprecated in favor of 'asarray'",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return ndx.asarray(var)
 
 

--- a/ndonnx/_dtypes.py
+++ b/ndonnx/_dtypes.py
@@ -89,7 +89,11 @@ class DType(ABC, Generic[TY_ARRAY_BASE]):
         return self.__class__.__name__
 
     def to_numpy_dtype(self) -> np.dtype:
-        warn("'to_numpy_dtype' is deprecated. Use `unwarp_numpy` method instead")
+        warn(
+            "'to_numpy_dtype' is deprecated. Use `unwarp_numpy` method instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         return self.unwrap_numpy()
 

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -76,7 +76,8 @@ def asarray(
             ):
                 # This is a list of ndonnx arrays
                 warn(
-                    "providing a sequence of 'Array's to 'asarray' is not defined by the array-api-standard and may be removed from ndonnx in the future"
+                    "providing a sequence of 'Array's to 'asarray' is not defined by the array-api-standard and may be removed from ndonnx in the future",
+                    stacklevel=2,
                 )
                 dtype = result_type(*np_arr.flatten()) if dtype is None else dtype
                 out = concat([a.astype(dtype)[None, ...] for a in np_arr.flatten()])

--- a/ndonnx/_propagation.py
+++ b/ndonnx/_propagation.py
@@ -9,6 +9,7 @@ from warnings import warn
 warn(
     "the 'ndonnx._propagation' module is deprecated and can be simply removed.",
     DeprecationWarning,
+    stacklevel=2,
 )
 
 F = TypeVar("F", bound=Callable[..., Any])

--- a/ndonnx/_typed_array/onnx.py
+++ b/ndonnx/_typed_array/onnx.py
@@ -71,7 +71,7 @@ def _inline(
     """Build the wrapped function as a self-contained ONNX graph and inline it.
 
     This is useful for functions which have to use the `If` operator
-    in order to work around bug in the onnxruntime. Without this
+    in order to work around bugs in the onnxruntime. Without this
     wrapper, value propagation will be executed in either arm of the
     `If` node and subsequently fail in one of them (it is the point of
     the `If` node to avoid the computation of the problematic branch

--- a/ndonnx/extensions.py
+++ b/ndonnx/extensions.py
@@ -37,6 +37,7 @@ def shape(x: ndx.Array, /) -> ndx.Array:
     warn(
         "'ndonnx.shape' is deprecated in favor of 'ndonnx.Array.dynamic_shape'",
         DeprecationWarning,
+        stacklevel=2,
     )
     return x.dynamic_shape
 


### PR DESCRIPTION
These changes make it so that the file and line number presented to the user match the call site, rather than where `warn` is called.