### PR TITLE
Fix `ndx.repeat` on min-onnxruntime for zero-sized inputs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,18 @@
 Changelog
 =========
 
+0.16.0 (unreleased)
+-------------------
+
+**Bug fix**
+
+- :func:`ndonnx.repeat` now works correctly for zero-sized inputs on the minimum supported onnxruntime 1.20.1.
+
+**New feature**
+
+- :func:`ndonnx.max` (:func:`ndonnx.min`) now returns the minimum (maximum) value for the input data type if the reduction takes place over a zero-sized input.
+
+
 0.15.0 (2025-08-13)
 -------------------
 

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -249,6 +249,11 @@ def cumulative_sum(
 def max(
     x: Array, /, *, axis: int | tuple[int, ...] | None = None, keepdims: bool = False
 ) -> Array:
+    """Calculates the maximum value of the input array x.
+
+    Reduction over zero-sized inputs return the minimum possible value for the input
+    data type.
+    """
     return Array._from_tyarray(x._tyarray.max(axis=axis, keepdims=keepdims))
 
 
@@ -289,6 +294,11 @@ def moveaxis(
 def min(
     x: Array, /, *, axis: int | tuple[int, ...] | None = None, keepdims: bool = False
 ) -> Array:
+    """Calculates the minimum value of the input array x.
+
+    Reduction over zero-sized inputs return the maximum possible value for the input
+    data type.
+    """
     return Array._from_tyarray(x._tyarray.min(axis=axis, keepdims=keepdims))
 
 

--- a/tests/test_manipulation_functions.py
+++ b/tests/test_manipulation_functions.py
@@ -38,6 +38,7 @@ def test_concat_axis_none_zero_sized():
         (np.ones((3, 0, 3)), 2, 2),
         (np.ones((3, 0, 3)), [2], 2),
         (np.ones((3, 0, 3)), [1, 0, 2], 2),
+        (np.ones((3, 0, 3)), [], 1),
         # other data types
         (["a", "b", "c"], np.asarray([2]), None),
         (np.asarray([1, 2, 3], dtype="datetime64[s]"), np.asarray([2]), None),
@@ -47,7 +48,7 @@ def test_repeat(x, repeats, axis):
     def do(npx):
         repeats_ = repeats
         if isinstance(repeats, list | np.ndarray):
-            repeats_ = npx.asarray(repeats_)
+            repeats_ = npx.asarray(repeats_, dtype=npx.int64)
         return npx.repeat(npx.asarray(x), repeats_, axis=axis)
 
     np.testing.assert_array_equal(do(ndx).unwrap_numpy(), do(np))


### PR DESCRIPTION
This PR fixes `ndonnx.repeat` on our minimum supported onnxruntime 1.20.1 as surfaced in our daily CI run. The existing implementation uses (essentially) `ndonnx.max`, which raises an error on 1.20.1 for zero-sized inputs. The array-api actually [mentions](https://data-apis.org/array-api/2024.12/API_specification/generated/array_api.max.html#max) that such input is implementation-defined. The ONNX standard explicitly [defines](https://github.com/onnx/onnx/blob/main/docs/Operators.md#reducemax) the behavior. Addressing the issue of `repeat` was most easily addressed by addressing the behavior of `ndonnx.{max, min}` for zero-sized inputs.

Closes #162 