### PR TITLE
Allow arrays as inputs to ndonnx.arange

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changelog
 **New feature**
 
 - :func:`ndonnx.max` (:func:`ndonnx.min`) now returns the minimum (maximum) value for the input data type if the reduction takes place over a zero-sized input.
+- :func:`ndonnx.arange` now also allows arrays as inputs.
 
 
 0.15.0 (2025-08-13)

--- a/ndonnx/_dtypes.py
+++ b/ndonnx/_dtypes.py
@@ -53,9 +53,9 @@ class DType(ABC, Generic[TY_ARRAY_BASE]):
     # Construction functions
     def __ndx_arange__(
         self,
-        start: int | float,
-        stop: int | float,
-        step: int | float = 1,
+        start: int | float | TyArrayBase,
+        stop: int | float | TyArrayBase,
+        step: int | float | TyArrayBase = 1,
     ) -> TY_ARRAY_BASE:
         return NotImplemented
 

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -105,34 +105,35 @@ def any(
 
 
 def arange(
-    start: int | float,
+    start: int | float | Array,
     /,
-    stop: int | float | None = None,
-    step: int | float = 1,
+    stop: int | float | Array | None = None,
+    step: int | float | Array = 1,
     *,
     dtype: DType | None = None,
     device: None | Device = None,
 ) -> Array:
-    if dtype is None:
-        if builtins.all(
-            isinstance(el, int) for el in [start, stop, step] if el is not None
-        ):
-            dtype = ndx._default_int
-        else:
-            dtype = ndx._default_float
-    dtype = dtype or ndx._default_float
+    sss = [start, stop, step]
+    for item in sss:
+        if item is None:
+            continue
+        if isinstance(item, Array):
+            if not item.ndim == 0:
+                raise ValueError("array arguments to 'arange' must be of rank 0")
+        elif not isinstance(item, int | float):
+            raise TypeError(
+                f"unexpected type for 'start', 'stop', or 'step': `{type(item)}`"
+            )
 
     if stop is None:
         stop = start
         start = 0
 
-    for el in [start, stop, step]:
-        if not isinstance(el, int | float):
-            raise TypeError(
-                f"unexpected type for 'start', 'stop', or 'step': `{type(el)}`"
-            )
+    array_or_scalar = [
+        el._tyarray if isinstance(el, Array) else el for el in [start, stop, step]
+    ]
 
-    return Array._from_tyarray(tyfuncs.arange(dtype, start, stop, step))
+    return Array._from_tyarray(tyfuncs.arange(dtype, *array_or_scalar))
 
 
 def argmax(x: Array, /, *, axis: int | None = None, keepdims: bool = False) -> Array:

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -113,8 +113,7 @@ def arange(
     dtype: DType | None = None,
     device: None | Device = None,
 ) -> Array:
-    sss = [start, stop, step]
-    for item in sss:
+    for item in [start, stop, step]:
         if item is None:
             continue
         if isinstance(item, Array):

--- a/ndonnx/_typed_array/funcs.py
+++ b/ndonnx/_typed_array/funcs.py
@@ -293,14 +293,28 @@ def minimum(
 
 
 def arange(
-    dtype: DType[TY_ARRAY_BASE_co],
-    start: int | float,
-    stop: int | float,
-    step: int | float = 1,
-) -> TY_ARRAY_BASE_co:
-    res = dtype.__ndx_arange__(start, stop, step)
-    if res is NotImplemented:
-        raise TypeError(f"'arange' is not implemented for `{dtype}`")
+    dtype: DType[TY_ARRAY_BASE_co] | None,
+    start: int | float | TyArrayBase,
+    stop: int | float | TyArrayBase,
+    step: int | float | TyArrayBase = 1,
+) -> TyArrayBase:
+    if dtype is None:
+        if all(isinstance(el, int) for el in [start, stop, step]):
+            dtypes: list[DType] = [onnx.int64]
+        elif all(isinstance(el, int | float) for el in [start, stop, step]):
+            dtypes = [onnx.float64]
+        else:
+            dtypes = [
+                el.dtype for el in [start, stop, step] if isinstance(el, TyArrayBase)
+            ]
+    else:
+        dtypes = [dtype]
+    for dtype_ in dtypes:
+        res = dtype_.__ndx_arange__(start, stop, step)
+        if res is not NotImplemented:
+            break
+    else:
+        raise ValueError("'arange' is not implemented for the provided inputs")
     return res
 
 

--- a/ndonnx/_typed_array/masked_onnx.py
+++ b/ndonnx/_typed_array/masked_onnx.py
@@ -84,12 +84,14 @@ class _MaOnnxDType(DType[TY_MA_ARRAY_ONNX]):
 
     def __ndx_arange__(
         self,
-        start: int | float,
-        stop: int | float,
-        step: int | float = 1,
+        start: int | float | TyArrayBase,
+        stop: int | float | TyArrayBase,
+        step: int | float | TyArrayBase = 1,
     ) -> TY_MA_ARRAY_ONNX:
         # Get everything onto the same type
         data = self._unmasked_dtype.__ndx_arange__(start, stop, step)
+        if data is NotImplemented:
+            return NotImplemented
         return self._build(data=data, mask=None)
 
     def __ndx_eye__(
@@ -117,7 +119,7 @@ class _MaOnnxDType(DType[TY_MA_ARRAY_ONNX]):
         return self._build(data=data, mask=None)
 
 
-class _NNumber(_MaOnnxDType):
+class _NNumber(_MaOnnxDType[TY_MA_ARRAY_ONNX]):
     def __ndx_result_type__(self, rhs: DType | PyScalar) -> DType | NotImplementedType:
         if isinstance(rhs, onnx.NumericDTypes | int | float):
             onnx_result = onnx.result_type(self._unmasked_dtype, rhs)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -424,38 +424,6 @@ def test_array_spox_interoperability():
     assert_array_equal(actual, expected)
 
 
-@pytest.mark.parametrize(
-    "start, stop, step, dtype",
-    [
-        (0, 10, 2, ndx.int64),
-        (-10, 0, 2, ndx.int64),
-        (-10, 0, 3, ndx.int64),
-        (1, 10, 1, ndx.int64),
-        (0.0, None, -1, ndx.int64),
-        # Hypothesis test cases
-        (
-            -9_223_371_349_660_010_402,
-            -9_223_370_112_709_427_707,
-            45_812_983_809,
-            ndx.float64,
-        ),
-        (-9_223_371_349_660_010_402, -9_223_371_349_660_010_401, 1, ndx.float64),
-    ],
-)
-def test_creation_arange(start, stop, step, dtype: ndx.DType | None):
-    def do(npx):
-        dtype_: np.dtype | ndx.DType | None = dtype
-        if dtype is not None and npx == np:
-            dtype_ = dtype.unwrap_numpy()
-        return npx.arange(start, stop, step, dtype=dtype_)
-
-    np_res, ndx_res = do(np), do(ndx).unwrap_numpy()
-
-    assert np_res.shape == ndx_res.shape
-    if np_res.size > 0:
-        np.testing.assert_array_equal(np_res[0], ndx_res[0])
-
-
 def test_creation_full():
     a = ndx.full((2, 3), 5)
     assert_array_equal(a.unwrap_numpy(), np.full((2, 3), 5))

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -1,0 +1,72 @@
+# Copyright (c) QuantCo 2023-2024
+# SPDX-License-Identifier: BSD-3-Clause
+
+import numpy as np
+import pytest
+
+import ndonnx as ndx
+
+
+@pytest.mark.parametrize(
+    "start, stop, step, dtype",
+    [
+        (0, 10, 2, ndx.int64),
+        (-10, 0, 2, ndx.int64),
+        (-10, 0, 3, ndx.int64),
+        (1, 10, 1, ndx.int64),
+        (0.0, None, -1, ndx.int64),
+        # Hypothesis test cases
+        (
+            -9_223_371_349_660_010_402,
+            -9_223_370_112_709_427_707,
+            45_812_983_809,
+            ndx.float64,
+        ),
+        (-9_223_371_349_660_010_402, -9_223_371_349_660_010_401, 1, ndx.float64),
+    ],
+)
+def test_arange_pyscalar(start, stop, step, dtype: ndx.DType | None):
+    def do(npx):
+        dtype_: np.dtype | ndx.DType | None = dtype
+        if dtype is not None and npx == np:
+            dtype_ = dtype.unwrap_numpy()
+        return npx.arange(start, stop, step, dtype=dtype_)
+
+    np_res, ndx_res = do(np), do(ndx).unwrap_numpy()
+
+    np.testing.assert_array_equal(np_res, ndx_res, strict=True)
+
+
+@pytest.mark.parametrize(
+    "start, stop, step",
+    [
+        (np.asarray(0.0), np.asarray(10.0), 1),
+        (np.asarray(0.0), 10.0, 1),
+        (np.asarray(10.0), None, 1),
+        (np.asarray(0, "datetime64[s]"), np.asarray(10, "datetime64[s]"), 1),
+        (np.asarray(0, "datetime64[s]"), np.asarray(10_000, "datetime64[ms]"), 1),
+        (
+            np.asarray(0, "datetime64[s]"),
+            np.asarray(10_000, "datetime64[ms]"),
+            np.asarray(1_000, "timedelta64[ms]"),
+        ),
+        (np.asarray(0, "timedelta64[s]"), np.asarray(10, "timedelta64[s]"), 1),
+        (np.asarray(0, "timedelta64[s]"), np.asarray(10_000, "timedelta64[ms]"), 1),
+        (
+            np.asarray(0, "timedelta64[s]"),
+            np.asarray(10_000, "timedelta64[ms]"),
+            np.asarray(1_000, "timedelta64[ms]"),
+        ),
+    ],
+)
+def test_arange_array_arg(start, stop, step):
+    def do(npx):
+        sss = [
+            el if isinstance(el, int | float | None) else npx.asarray(el)
+            for el in [start, stop, step]
+        ]
+        return npx.arange(*sss)
+
+    np_res, ndx_res = do(np), do(ndx).unwrap_numpy()
+
+    np.testing.assert_array_equal(np_res[0], ndx_res[0], strict=True)

--- a/tests/test_masked.py
+++ b/tests/test_masked.py
@@ -121,9 +121,9 @@ def test_unary_none_propagation(fn_name, args, kwargs):
 
 
 def test_forbidden_masked():
-    a = ndx.argument(shape=(3,), dtype=ndx.nint64)
+    a = ndx.argument(shape=(), dtype=ndx.nint64)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         ndx.arange(a, 0, 1)
 
 


### PR DESCRIPTION
Possibly the most requested feature is finally here 🥳 !

This PR does what it says in the title. Array inputs are essentially passed down to the individual implementations untouched, which may return `NotImplemented`. If no `dtype` is specified but at least one argument is an `Array`, we try the array dtypes until we find one that does not return `NotImplemented`.