### PR TITLE
Fix ndonnx.clip for integer dtype array with float type min/max values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@
 Changelog
 =========
 
+0.17.0 (unreleased)
+-------------------
+
+**Bug fix**
+
+- :func:`ndonnx.clip` now works correctly when an integer dtype array and float type min or max values are given
+
 0.16.0 (2025-08-20)
 -------------------
 

--- a/ndonnx/_elementwise.py
+++ b/ndonnx/_elementwise.py
@@ -127,7 +127,7 @@ def clip(
 
     min_ = None if min is None else ndx.asarray(min, dtype=dtype)._tyarray
     max_ = None if max is None else ndx.asarray(max, dtype=dtype)._tyarray
-    return Array._from_tyarray(x._tyarray.clip(min=min_, max=max_))
+    return Array._from_tyarray(x._tyarray.astype(dtype).clip(min=min_, max=max_))
 
 
 def cos(x: Array, /) -> Array:

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2024
+# Copyright (c) QuantCo 2023-2025
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -189,7 +189,7 @@ def test_clip():
 )
 def test_int_float_clip():
     def do(npx):
-        return npx.clip(npx.asarray([1,2]), min=1.5, max=1.5)
+        return npx.clip(npx.asarray([1, 2]), min=1.5, max=1.5)
 
     np.testing.assert_array_equal(do(ndx).unwrap_numpy(), do(np))
 

--- a/tests/test_free_functions.py
+++ b/tests/test_free_functions.py
@@ -187,6 +187,16 @@ def test_clip():
 @pytest.mark.skipif(
     np.__version__ < "2", reason="'clip' has a different API in NumPy 1.x"
 )
+def test_int_float_clip():
+    def do(npx):
+        return npx.clip(npx.asarray([1,2]), min=1.5, max=1.5)
+
+    np.testing.assert_array_equal(do(ndx).unwrap_numpy(), do(np))
+
+
+@pytest.mark.skipif(
+    np.__version__ < "2", reason="'clip' has a different API in NumPy 1.x"
+)
 def test_minimum():
     def do(npx):
         return npx.minimum(npx.asarray([2147483648] * 2, dtype=npx.int64), 0)


### PR DESCRIPTION
``ndonnx.clip`` did not work correctly when given an integer dtype ``ndonnx.Array`` and float type values as min/max arguments because it did not cast the output array's type correctly.
I came across this bug when testing ndonnx/pdonnx support in quantcore.learn.