### PR TITLE
Add dtype aliases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,31 @@
 Changelog
 =========
 
+0.21.0 (unreleased)
+-------------------
+
+**New feature**
+
+- Most functions and methods accepting ``dtype`` as an argument now support the following aliases:
+  - ``bool``: ``ndonnx.bool``
+  - ``int``: ``ndonnx.int64``
+  - ``float``: ``ndonnx.float64``
+  - ``"bool"``: ``ndonnx.bool``
+  - ``"int"``: ``ndonnx.int64``
+  - ``"float"``: ``ndonnx.float64``
+  - ``"int8"``: ``ndonnx.int8``
+  - ``"int16"``: ``ndonnx.int16``
+  - ``"int32"``: ``ndonnx.int32``
+  - ``"int64"``: ``ndonnx.int64``
+  - ``"uint8"``: ``ndonnx.uint8``
+  - ``"uint16"``: ``ndonnx.uint16``
+  - ``"uint32"``: ``ndonnx.uint32``
+  - ``"uint64"``: ``ndonnx.uint64``
+  - ``"float16"``: ``ndonnx.float16``
+  - ``"float32"``: ``ndonnx.float32``
+  - ``"float64"``: ``ndonnx.float64``
+
+
 0.20.0 (2026-06-16)
 -------------------
 

--- a/ndonnx/_array.py
+++ b/ndonnx/_array.py
@@ -16,7 +16,6 @@ from typing_extensions import deprecated
 
 from ndonnx import DType
 
-from ._dtypes import normalize_dtype
 from ._namespace_info import Device, device
 from ._typed_array import TyArrayBase, onnx
 from ._typed_array import funcs as tyfuncs
@@ -239,6 +238,8 @@ class Array:
         raise ValueError(f"`{self.dtype}` is not a nullable built-in type")
 
     def astype(self, dtype: DType | DTypeAlias, *, copy=True) -> Array:
+        from ._funcs import normalize_dtype  # avoid a circular import
+
         dtype = normalize_dtype(dtype)
         new_data = self._tyarray.astype(dtype, copy=copy)
         return Array._from_tyarray(new_data)

--- a/ndonnx/_array.py
+++ b/ndonnx/_array.py
@@ -16,6 +16,7 @@ from typing_extensions import deprecated
 
 from ndonnx import DType
 
+from ._dtypes import normalize_dtype
 from ._namespace_info import Device, device
 from ._typed_array import TyArrayBase, onnx
 from ._typed_array import funcs as tyfuncs
@@ -238,7 +239,7 @@ class Array:
         raise ValueError(f"`{self.dtype}` is not a nullable built-in type")
 
     def astype(self, dtype: DType | DTypeAlias, *, copy=True) -> Array:
-        dtype = tyfuncs.map_python_dtype(dtype)
+        dtype = normalize_dtype(dtype)
         new_data = self._tyarray.astype(dtype, copy=copy)
         return Array._from_tyarray(new_data)
 

--- a/ndonnx/_array.py
+++ b/ndonnx/_array.py
@@ -21,7 +21,7 @@ from ._typed_array import TyArrayBase, onnx
 from ._typed_array import funcs as tyfuncs
 from ._typed_array.masked_onnx import TyMaArray
 from .extensions import get_mask
-from .types import GetItemKey, OnnxShape, PyScalar, SetitemKey
+from .types import GetItemKey, OnnxShape, PyScalar, PyScalarType, SetitemKey
 
 _BinaryOp = Callable[
     ["Array", "PyScalar | Array | np.ndarray | np.generic"],
@@ -237,7 +237,8 @@ class Array:
             return Array._from_tyarray(self._tyarray)
         raise ValueError(f"`{self.dtype}` is not a nullable built-in type")
 
-    def astype(self, dtype: DType, *, copy=True) -> Array:
+    def astype(self, dtype: DType | PyScalarType, *, copy=True) -> Array:
+        dtype = tyfuncs.map_python_dtype(dtype)
         new_data = self._tyarray.astype(dtype, copy=copy)
         return Array._from_tyarray(new_data)
 

--- a/ndonnx/_array.py
+++ b/ndonnx/_array.py
@@ -21,7 +21,7 @@ from ._typed_array import TyArrayBase, onnx
 from ._typed_array import funcs as tyfuncs
 from ._typed_array.masked_onnx import TyMaArray
 from .extensions import get_mask
-from .types import GetItemKey, OnnxShape, PyScalar, PyScalarType, SetitemKey
+from .types import DTypeAlias, GetItemKey, OnnxShape, PyScalar, SetitemKey
 
 _BinaryOp = Callable[
     ["Array", "PyScalar | Array | np.ndarray | np.generic"],
@@ -237,7 +237,7 @@ class Array:
             return Array._from_tyarray(self._tyarray)
         raise ValueError(f"`{self.dtype}` is not a nullable built-in type")
 
-    def astype(self, dtype: DType | PyScalarType, *, copy=True) -> Array:
+    def astype(self, dtype: DType | DTypeAlias, *, copy=True) -> Array:
         dtype = tyfuncs.map_python_dtype(dtype)
         new_data = self._tyarray.astype(dtype, copy=copy)
         return Array._from_tyarray(new_data)

--- a/ndonnx/_dtypes.py
+++ b/ndonnx/_dtypes.py
@@ -100,16 +100,6 @@ class DType(ABC, Generic[TY_ARRAY_BASE]):
         raise ValueError(f"`{self}` provides no corresponding NumPy data type")
 
 
-DTYPE_ALIAS_MAP: dict[DTypeAlias, DType] = {
-    bool: onnx.bool_,
-    "bool": onnx.bool_,
-    int: onnx.int64,
-    "int": onnx.int64,
-    float: onnx.float64,
-    "float": onnx.float64,
-}
-
-
 @overload
 def normalize_dtype(dtype: None) -> None: ...
 
@@ -122,6 +112,20 @@ def normalize_dtype(dtype: DType | DTypeAlias | None) -> DType | None:
     """Normalize a ``dtype`` argument, mapping aliases to DType instances."""
     if dtype is None or isinstance(dtype, DType):
         return dtype
-    if mapped_dtype := DTYPE_ALIAS_MAP.get(dtype):
+
+    # Avoid a circular import.
+    from ._typed_array import onnx
+
+    dtype_alias_map = {
+        bool: onnx.bool_,
+        "bool": onnx.bool_,
+        int: onnx.int64,
+        "int": onnx.int64,
+        float: onnx.float64,
+        "float": onnx.float64,
+    }
+
+    if mapped_dtype := dtype_alias_map.get(dtype):
         return mapped_dtype
+
     raise TypeError(f"unrecognized dtype argument: `{dtype}`")

--- a/ndonnx/_dtypes.py
+++ b/ndonnx/_dtypes.py
@@ -5,13 +5,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from types import NotImplementedType
-from typing import TYPE_CHECKING, Generic, TypeVar, overload
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 import numpy as np
 from spox import Var
 from typing_extensions import deprecated
-
-from ndonnx.types import DTypeAlias
 
 if TYPE_CHECKING:
     from ndonnx.types import NestedSequence, OnnxShape, PyScalar
@@ -98,34 +96,3 @@ class DType(ABC, Generic[TY_ARRAY_BASE]):
 
     def unwrap_numpy(self) -> np.dtype:
         raise ValueError(f"`{self}` provides no corresponding NumPy data type")
-
-
-@overload
-def normalize_dtype(dtype: None) -> None: ...
-
-
-@overload
-def normalize_dtype(dtype: DType | DTypeAlias) -> DType: ...
-
-
-def normalize_dtype(dtype: DType | DTypeAlias | None) -> DType | None:
-    """Normalize a ``dtype`` argument, mapping aliases to DType instances."""
-    if dtype is None or isinstance(dtype, DType):
-        return dtype
-
-    # Avoid a circular import.
-    from ._typed_array import onnx
-
-    dtype_alias_map = {
-        bool: onnx.bool_,
-        "bool": onnx.bool_,
-        int: onnx.int64,
-        "int": onnx.int64,
-        float: onnx.float64,
-        "float": onnx.float64,
-    }
-
-    if mapped_dtype := dtype_alias_map.get(dtype):
-        return mapped_dtype
-
-    raise TypeError(f"unrecognized dtype argument: `{dtype}`")

--- a/ndonnx/_dtypes.py
+++ b/ndonnx/_dtypes.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from types import NotImplementedType
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar, overload
 
 import numpy as np
 from spox import Var
 from typing_extensions import deprecated
+
+from ndonnx.types import DTypeAlias
 
 if TYPE_CHECKING:
     from ndonnx.types import NestedSequence, OnnxShape, PyScalar
@@ -96,3 +98,30 @@ class DType(ABC, Generic[TY_ARRAY_BASE]):
 
     def unwrap_numpy(self) -> np.dtype:
         raise ValueError(f"`{self}` provides no corresponding NumPy data type")
+
+
+DTYPE_ALIAS_MAP: dict[DTypeAlias, DType] = {
+    bool: onnx.bool_,
+    "bool": onnx.bool_,
+    int: onnx.int64,
+    "int": onnx.int64,
+    float: onnx.float64,
+    "float": onnx.float64,
+}
+
+
+@overload
+def normalize_dtype(dtype: None) -> None: ...
+
+
+@overload
+def normalize_dtype(dtype: DType | DTypeAlias) -> DType: ...
+
+
+def normalize_dtype(dtype: DType | DTypeAlias | None) -> DType | None:
+    """Normalize a ``dtype`` argument, mapping aliases to DType instances."""
+    if dtype is None or isinstance(dtype, DType):
+        return dtype
+    if mapped_dtype := DTYPE_ALIAS_MAP.get(dtype):
+        return mapped_dtype
+    raise TypeError(f"unrecognized dtype argument: `{dtype}`")

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -13,7 +13,7 @@ import numpy as np
 from spox import Var
 
 import ndonnx as ndx
-from ndonnx.types import NestedSequence, OnnxShape, PyScalar, PyScalarType
+from ndonnx.types import DTypeAlias, NestedSequence, OnnxShape, PyScalar
 
 from ._array import Array, DType
 from ._array_tyarray_interop import unwrap_tyarray
@@ -25,7 +25,7 @@ from ._typed_array import onnx
 def argument(
     *,
     shape: OnnxShape,
-    dtype: ndx.DType | PyScalarType,
+    dtype: ndx.DType | DTypeAlias,
 ) -> Array:
     """Creates a new lazy ndonnx array.
 
@@ -51,7 +51,7 @@ def asarray(
     obj: Array | PyScalar | np.ndarray | NestedSequence | Var,
     /,
     *,
-    dtype: ndx.DType | PyScalarType | None = None,
+    dtype: ndx.DType | DTypeAlias | None = None,
     device: None | Device = None,
     copy: bool | None = None,
 ) -> Array:
@@ -112,7 +112,7 @@ def arange(
     stop: int | float | Array | None = None,
     step: int | float | Array = 1,
     *,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
     for item in [start, stop, step]:
@@ -169,7 +169,7 @@ def nonzero(x: Array, /) -> tuple[Array, ...]:
 
 def astype(
     x: Array,
-    dtype: DType | PyScalarType,
+    dtype: DType | DTypeAlias,
     /,
     *,
     copy: bool = True,
@@ -231,7 +231,7 @@ def cumulative_prod(
     /,
     *,
     axis: int | None = None,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     include_initial: bool = False,
 ) -> Array:
     dtype = tyfuncs.map_python_dtype(dtype)
@@ -246,7 +246,7 @@ def cumulative_sum(
     /,
     *,
     axis: int | None = None,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     include_initial: bool = False,
 ) -> Array:
     dtype = tyfuncs.map_python_dtype(dtype)
@@ -317,7 +317,7 @@ def prod(
     /,
     *,
     axis: int | tuple[int, ...] | None = None,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     keepdims: bool = False,
 ) -> Array:
     dtype = tyfuncs.map_python_dtype(dtype)
@@ -352,7 +352,7 @@ def sum(
     /,
     *,
     axis: int | tuple[int, ...] | None = None,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     keepdims: bool = False,
 ) -> Array:
     dtype = tyfuncs.map_python_dtype(dtype)
@@ -377,7 +377,7 @@ def var(
 def empty(
     shape: int | tuple[int, ...],
     *,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
     return zeros(shape=shape, dtype=dtype)
@@ -387,7 +387,7 @@ def empty_like(
     x: Array,
     /,
     *,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
     return zeros_like(x, dtype=dtype)
@@ -436,7 +436,7 @@ def eye(
     /,
     *,
     k: int = 0,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
     nparr = np.eye(n_rows, n_cols, k=k)
@@ -459,7 +459,7 @@ def full(
     shape: int | tuple[int, ...] | Array,
     fill_value: bool | int | float | str,
     *,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
     dtype = tyfuncs.map_python_dtype(dtype)
@@ -488,7 +488,7 @@ def full_like(
     /,
     fill_value: bool | int | float | str,
     *,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
     dtype = tyfuncs.map_python_dtype(dtype)
@@ -527,7 +527,7 @@ def linspace(
     /,
     num: int,
     *,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
     endpoint: bool = True,
 ) -> Array:
@@ -548,7 +548,7 @@ def matrix_transpose(x: Array, /) -> Array:
 def ones(
     shape: int | tuple[int, ...],
     *,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
     dtype = tyfuncs.map_python_dtype(dtype) or ndx._default_float
@@ -560,7 +560,7 @@ def ones_like(
     x: Array,
     /,
     *,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
     dtype = tyfuncs.map_python_dtype(dtype) or x.dtype
@@ -796,7 +796,7 @@ def where(
 def zeros(
     shape: int | tuple[int, ...],
     *,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
     dtype = tyfuncs.map_python_dtype(dtype) or ndx._default_float
@@ -808,7 +808,7 @@ def zeros_like(
     x: Array,
     /,
     *,
-    dtype: DType | PyScalarType | None = None,
+    dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
     dtype = tyfuncs.map_python_dtype(dtype) or x.dtype

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -13,7 +13,7 @@ import numpy as np
 from spox import Var
 
 import ndonnx as ndx
-from ndonnx.types import NestedSequence, OnnxShape, PyScalar
+from ndonnx.types import NestedSequence, OnnxShape, PyScalar, PyScalarType
 
 from ._array import Array, DType
 from ._array_tyarray_interop import unwrap_tyarray
@@ -25,7 +25,7 @@ from ._typed_array import onnx
 def argument(
     *,
     shape: OnnxShape,
-    dtype: ndx.DType,
+    dtype: ndx.DType | PyScalarType,
 ) -> Array:
     """Creates a new lazy ndonnx array.
 
@@ -43,6 +43,7 @@ def argument(
         Array
             The new array representing input(s) of the computational graphs.
     """
+    dtype = tyfuncs.map_python_dtype(dtype)
     return Array._argument(shape=shape, dtype=dtype)
 
 
@@ -50,7 +51,7 @@ def asarray(
     obj: Array | PyScalar | np.ndarray | NestedSequence | Var,
     /,
     *,
-    dtype: ndx.DType | None = None,
+    dtype: ndx.DType | PyScalarType | None = None,
     device: None | Device = None,
     copy: bool | None = None,
 ) -> Array:
@@ -111,7 +112,7 @@ def arange(
     stop: int | float | Array | None = None,
     step: int | float | Array = 1,
     *,
-    dtype: DType | None = None,
+    dtype: DType | PyScalarType | None = None,
     device: None | Device = None,
 ) -> Array:
     for item in [start, stop, step]:
@@ -167,8 +168,14 @@ def nonzero(x: Array, /) -> tuple[Array, ...]:
 
 
 def astype(
-    x: Array, dtype: DType, /, *, copy: bool = True, device: None | Device = None
+    x: Array,
+    dtype: DType | PyScalarType,
+    /,
+    *,
+    copy: bool = True,
+    device: None | Device = None,
 ) -> Array:
+    dtype = tyfuncs.map_python_dtype(dtype)
     if not copy and x.dtype == dtype:
         return x
     return x.astype(dtype)
@@ -224,9 +231,10 @@ def cumulative_prod(
     /,
     *,
     axis: int | None = None,
-    dtype: DType | None = None,
+    dtype: DType | PyScalarType | None = None,
     include_initial: bool = False,
 ) -> Array:
+    dtype = tyfuncs.map_python_dtype(dtype)
     data = x._tyarray.cumulative_prod(
         axis=axis, dtype=dtype, include_initial=include_initial
     )
@@ -238,9 +246,10 @@ def cumulative_sum(
     /,
     *,
     axis: int | None = None,
-    dtype: DType | None = None,
+    dtype: DType | PyScalarType | None = None,
     include_initial: bool = False,
 ) -> Array:
+    dtype = tyfuncs.map_python_dtype(dtype)
     data = x._tyarray.cumulative_sum(
         axis=axis, dtype=dtype, include_initial=include_initial
     )
@@ -308,9 +317,10 @@ def prod(
     /,
     *,
     axis: int | tuple[int, ...] | None = None,
-    dtype: DType | None = None,
+    dtype: DType | PyScalarType | None = None,
     keepdims: bool = False,
 ) -> Array:
+    dtype = tyfuncs.map_python_dtype(dtype)
     return Array._from_tyarray(
         x._tyarray.prod(axis=axis, dtype=dtype, keepdims=keepdims)
     )
@@ -342,9 +352,10 @@ def sum(
     /,
     *,
     axis: int | tuple[int, ...] | None = None,
-    dtype: DType | None = None,
+    dtype: DType | PyScalarType | None = None,
     keepdims: bool = False,
 ) -> Array:
+    dtype = tyfuncs.map_python_dtype(dtype)
     return Array._from_tyarray(
         x._tyarray.sum(axis=axis, dtype=dtype, keepdims=keepdims)
     )
@@ -366,14 +377,18 @@ def var(
 def empty(
     shape: int | tuple[int, ...],
     *,
-    dtype: DType | None = None,
+    dtype: DType | PyScalarType | None = None,
     device: None | Device = None,
 ) -> Array:
     return zeros(shape=shape, dtype=dtype)
 
 
 def empty_like(
-    x: Array, /, *, dtype: DType | None = None, device: None | Device = None
+    x: Array,
+    /,
+    *,
+    dtype: DType | PyScalarType | None = None,
+    device: None | Device = None,
 ) -> Array:
     return zeros_like(x, dtype=dtype)
 
@@ -421,7 +436,7 @@ def eye(
     /,
     *,
     k: int = 0,
-    dtype: DType | None = None,
+    dtype: DType | PyScalarType | None = None,
     device: None | Device = None,
 ) -> Array:
     nparr = np.eye(n_rows, n_cols, k=k)
@@ -444,9 +459,10 @@ def full(
     shape: int | tuple[int, ...] | Array,
     fill_value: bool | int | float | str,
     *,
-    dtype: DType | None = None,
+    dtype: DType | PyScalarType | None = None,
     device: None | Device = None,
 ) -> Array:
+    dtype = tyfuncs.map_python_dtype(dtype)
     if dtype is None:
         dtype = tyfuncs._infer_dtype(fill_value)
 
@@ -472,9 +488,10 @@ def full_like(
     /,
     fill_value: bool | int | float | str,
     *,
-    dtype: DType | None = None,
+    dtype: DType | PyScalarType | None = None,
     device: None | Device = None,
 ) -> Array:
+    dtype = tyfuncs.map_python_dtype(dtype)
     shape = x.dynamic_shape
     fill = asarray(fill_value, dtype=dtype or x.dtype)
     return broadcast_to(fill, shape)
@@ -510,11 +527,11 @@ def linspace(
     /,
     num: int,
     *,
-    dtype: DType | None = None,
+    dtype: DType | PyScalarType | None = None,
     device: None | Device = None,
     endpoint: bool = True,
 ) -> Array:
-    dtype = dtype or ndx._default_float
+    dtype = tyfuncs.map_python_dtype(dtype) or ndx._default_float
     if not isinstance(dtype, onnx.DTypes):
         raise ValueError(f"only primitive data types are supported, found `{dtype}`")
     return asarray(np.linspace(start, stop, num=num, endpoint=endpoint), dtype=dtype)
@@ -531,18 +548,22 @@ def matrix_transpose(x: Array, /) -> Array:
 def ones(
     shape: int | tuple[int, ...],
     *,
-    dtype: DType | None = None,
+    dtype: DType | PyScalarType | None = None,
     device: None | Device = None,
 ) -> Array:
-    dtype = dtype or ndx._default_float
+    dtype = tyfuncs.map_python_dtype(dtype) or ndx._default_float
     shape = (shape,) if isinstance(shape, int) else shape
     return Array._from_tyarray(tyfuncs.ones(dtype, shape))
 
 
 def ones_like(
-    x: Array, /, *, dtype: DType | None = None, device: None | Device = None
+    x: Array,
+    /,
+    *,
+    dtype: DType | PyScalarType | None = None,
+    device: None | Device = None,
 ) -> Array:
-    dtype = dtype or x.dtype
+    dtype = tyfuncs.map_python_dtype(dtype) or x.dtype
     return full_like(x, 1, dtype=dtype)
 
 
@@ -775,18 +796,22 @@ def where(
 def zeros(
     shape: int | tuple[int, ...],
     *,
-    dtype: DType | None = None,
+    dtype: DType | PyScalarType | None = None,
     device: None | Device = None,
 ) -> Array:
-    dtype = dtype or ndx._default_float
+    dtype = tyfuncs.map_python_dtype(dtype) or ndx._default_float
     shape = (shape,) if isinstance(shape, int) else shape
     return Array._from_tyarray(tyfuncs.zeros(dtype, shape))
 
 
 def zeros_like(
-    x: Array, /, *, dtype: DType | None = None, device: None | Device = None
+    x: Array,
+    /,
+    *,
+    dtype: DType | PyScalarType | None = None,
+    device: None | Device = None,
 ) -> Array:
-    dtype = dtype or x.dtype
+    dtype = tyfuncs.map_python_dtype(dtype) or x.dtype
     return full_like(x, 0, dtype=dtype)
 
 

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -17,6 +17,7 @@ from ndonnx.types import DTypeAlias, NestedSequence, OnnxShape, PyScalar
 
 from ._array import Array, DType
 from ._array_tyarray_interop import unwrap_tyarray
+from ._dtypes import normalize_dtype
 from ._namespace_info import Device
 from ._typed_array import funcs as tyfuncs
 from ._typed_array import onnx
@@ -43,7 +44,7 @@ def argument(
         Array
             The new array representing input(s) of the computational graphs.
     """
-    dtype = tyfuncs.map_python_dtype(dtype)
+    dtype = normalize_dtype(dtype)
     return Array._argument(shape=shape, dtype=dtype)
 
 
@@ -55,6 +56,7 @@ def asarray(
     device: None | Device = None,
     copy: bool | None = None,
 ) -> Array:
+    dtype = normalize_dtype(dtype)
     if not copy and copy is not None:
         # Must copy or raise
         if not isinstance(obj, Array):
@@ -115,6 +117,7 @@ def arange(
     dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
+    dtype = normalize_dtype(dtype)
     for item in [start, stop, step]:
         if item is None:
             continue
@@ -175,7 +178,7 @@ def astype(
     copy: bool = True,
     device: None | Device = None,
 ) -> Array:
-    dtype = tyfuncs.map_python_dtype(dtype)
+    dtype = normalize_dtype(dtype)
     if not copy and x.dtype == dtype:
         return x
     return x.astype(dtype)
@@ -234,7 +237,7 @@ def cumulative_prod(
     dtype: DType | DTypeAlias | None = None,
     include_initial: bool = False,
 ) -> Array:
-    dtype = tyfuncs.map_python_dtype(dtype)
+    dtype = normalize_dtype(dtype)
     data = x._tyarray.cumulative_prod(
         axis=axis, dtype=dtype, include_initial=include_initial
     )
@@ -249,7 +252,7 @@ def cumulative_sum(
     dtype: DType | DTypeAlias | None = None,
     include_initial: bool = False,
 ) -> Array:
-    dtype = tyfuncs.map_python_dtype(dtype)
+    dtype = normalize_dtype(dtype)
     data = x._tyarray.cumulative_sum(
         axis=axis, dtype=dtype, include_initial=include_initial
     )
@@ -320,7 +323,7 @@ def prod(
     dtype: DType | DTypeAlias | None = None,
     keepdims: bool = False,
 ) -> Array:
-    dtype = tyfuncs.map_python_dtype(dtype)
+    dtype = normalize_dtype(dtype)
     return Array._from_tyarray(
         x._tyarray.prod(axis=axis, dtype=dtype, keepdims=keepdims)
     )
@@ -355,7 +358,7 @@ def sum(
     dtype: DType | DTypeAlias | None = None,
     keepdims: bool = False,
 ) -> Array:
-    dtype = tyfuncs.map_python_dtype(dtype)
+    dtype = normalize_dtype(dtype)
     return Array._from_tyarray(
         x._tyarray.sum(axis=axis, dtype=dtype, keepdims=keepdims)
     )
@@ -462,7 +465,7 @@ def full(
     dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
-    dtype = tyfuncs.map_python_dtype(dtype)
+    dtype = normalize_dtype(dtype)
     if dtype is None:
         dtype = tyfuncs._infer_dtype(fill_value)
 
@@ -491,7 +494,7 @@ def full_like(
     dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
-    dtype = tyfuncs.map_python_dtype(dtype)
+    dtype = normalize_dtype(dtype)
     shape = x.dynamic_shape
     fill = asarray(fill_value, dtype=dtype or x.dtype)
     return broadcast_to(fill, shape)
@@ -531,7 +534,7 @@ def linspace(
     device: None | Device = None,
     endpoint: bool = True,
 ) -> Array:
-    dtype = tyfuncs.map_python_dtype(dtype) or ndx._default_float
+    dtype = normalize_dtype(dtype) or ndx._default_float
     if not isinstance(dtype, onnx.DTypes):
         raise ValueError(f"only primitive data types are supported, found `{dtype}`")
     return asarray(np.linspace(start, stop, num=num, endpoint=endpoint), dtype=dtype)
@@ -551,7 +554,7 @@ def ones(
     dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
-    dtype = tyfuncs.map_python_dtype(dtype) or ndx._default_float
+    dtype = normalize_dtype(dtype) or ndx._default_float
     shape = (shape,) if isinstance(shape, int) else shape
     return Array._from_tyarray(tyfuncs.ones(dtype, shape))
 
@@ -563,7 +566,7 @@ def ones_like(
     dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
-    dtype = tyfuncs.map_python_dtype(dtype) or x.dtype
+    dtype = normalize_dtype(dtype) or x.dtype
     return full_like(x, 1, dtype=dtype)
 
 
@@ -799,7 +802,7 @@ def zeros(
     dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
-    dtype = tyfuncs.map_python_dtype(dtype) or ndx._default_float
+    dtype = normalize_dtype(dtype) or ndx._default_float
     shape = (shape,) if isinstance(shape, int) else shape
     return Array._from_tyarray(tyfuncs.zeros(dtype, shape))
 
@@ -811,7 +814,7 @@ def zeros_like(
     dtype: DType | DTypeAlias | None = None,
     device: None | Device = None,
 ) -> Array:
-    dtype = tyfuncs.map_python_dtype(dtype) or x.dtype
+    dtype = normalize_dtype(dtype) or x.dtype
     return full_like(x, 0, dtype=dtype)
 
 

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import builtins
 import math
 from collections.abc import Sequence
-from typing import Literal, NamedTuple
+from typing import Literal, NamedTuple, overload
 from warnings import warn
 
 import numpy as np
@@ -17,10 +17,47 @@ from ndonnx.types import DTypeAlias, NestedSequence, OnnxShape, PyScalar
 
 from ._array import Array, DType
 from ._array_tyarray_interop import unwrap_tyarray
-from ._dtypes import normalize_dtype
 from ._namespace_info import Device
 from ._typed_array import funcs as tyfuncs
 from ._typed_array import onnx
+
+DTYPE_ALIAS_MAP = {
+    bool: onnx.bool_,
+    int: onnx.int64,
+    float: onnx.float64,
+    "bool": onnx.bool_,
+    "int": onnx.int64,
+    "float": onnx.float64,
+    "int8": onnx.int8,
+    "int16": onnx.int16,
+    "int32": onnx.int32,
+    "int64": onnx.int64,
+    "uint8": onnx.uint8,
+    "uint16": onnx.uint16,
+    "uint32": onnx.uint32,
+    "uint64": onnx.uint64,
+    "float16": onnx.float16,
+    "float32": onnx.float32,
+    "float64": onnx.float64,
+}
+
+
+@overload
+def normalize_dtype(dtype: None) -> None: ...
+
+
+@overload
+def normalize_dtype(dtype: DType | DTypeAlias) -> DType: ...
+
+
+def normalize_dtype(dtype: DType | DTypeAlias | None) -> DType | None:
+    """Normalize a ``dtype`` argument, mapping aliases to DType instances."""
+    if dtype is None or isinstance(dtype, DType):
+        return dtype
+    if mapped_dtype := DTYPE_ALIAS_MAP.get(dtype):
+        return mapped_dtype
+
+    raise TypeError(f"unrecognized dtype argument: `{dtype}`")
 
 
 def argument(

--- a/ndonnx/_typed_array/funcs.py
+++ b/ndonnx/_typed_array/funcs.py
@@ -20,9 +20,11 @@ TY_ARRAY_BASE_co = TypeVar("TY_ARRAY_BASE_co", bound="TyArrayBase", covariant=Tr
 
 PYTHON_DTYPE_MAP: dict[PyScalarType, DType] = {
     bool: onnx.bool_,
+    "bool": onnx.bool_,
     int: onnx.int64,
+    "int": onnx.int64,
     float: onnx.float64,
-    str: onnx.utf8,
+    "float": onnx.float64,
 }
 
 

--- a/ndonnx/_typed_array/funcs.py
+++ b/ndonnx/_typed_array/funcs.py
@@ -11,38 +11,12 @@ import numpy as np
 from spox import Var
 
 from ndonnx import DType, from_numpy_dtype
-from ndonnx.types import DTypeAlias, NestedSequence, PyScalar
+from ndonnx.types import NestedSequence, PyScalar
 
 from . import TyArrayBase, datetime, masked_onnx, onnx, promote
 from ._utils import validate_op_result
 
 TY_ARRAY_BASE_co = TypeVar("TY_ARRAY_BASE_co", bound="TyArrayBase", covariant=True)
-
-PYTHON_DTYPE_MAP: dict[DTypeAlias, DType] = {
-    bool: onnx.bool_,
-    "bool": onnx.bool_,
-    int: onnx.int64,
-    "int": onnx.int64,
-    float: onnx.float64,
-    "float": onnx.float64,
-}
-
-
-@overload
-def map_python_dtype(dtype: None) -> None: ...
-
-
-@overload
-def map_python_dtype(dtype: DType | DTypeAlias) -> DType: ...
-
-
-def map_python_dtype(dtype: DType | DTypeAlias | None) -> DType | None:
-    """Intercept a ``dtype`` argument to support Python type aliases."""
-    if dtype is None or isinstance(dtype, DType):
-        return dtype
-    if mapped_dtype := PYTHON_DTYPE_MAP.get(dtype):
-        return mapped_dtype
-    raise TypeError(f"unrecognized dtype argument: `{dtype}`")
 
 
 def _infer_sequence(
@@ -104,19 +78,18 @@ def astyarray(
 @overload
 def astyarray(
     val: PyScalar | np.ndarray | TyArrayBase | Var | NestedSequence,
-    dtype: None | DTypeAlias | DType = None,
+    dtype: None | DType = None,
 ) -> TyArrayBase: ...
 
 
 def astyarray(
     val: PyScalar | np.ndarray | TyArrayBase | Var | NestedSequence,
-    dtype: None | DTypeAlias | DType[TY_ARRAY_BASE_co] = None,
+    dtype: None | DType[TY_ARRAY_BASE_co] = None,
 ) -> TyArrayBase:
     """Conversion of values of various types into a built-in typed array.
 
     This function always copies.
     """
-    dtype = map_python_dtype(dtype)
     inferred_dtype = _infer_dtype(val) if dtype is None else dtype
     res = inferred_dtype.__ndx_create__(val)
     if res is NotImplemented:
@@ -320,12 +293,11 @@ def minimum(
 
 
 def arange(
-    dtype: DType[TY_ARRAY_BASE_co] | DTypeAlias | None,
+    dtype: DType[TY_ARRAY_BASE_co] | None,
     start: int | float | TyArrayBase,
     stop: int | float | TyArrayBase,
     step: int | float | TyArrayBase = 1,
-) -> TY_ARRAY_BASE_co:
-    dtype = map_python_dtype(dtype)
+) -> TyArrayBase:
     if dtype is None:
         if all(isinstance(el, int) for el in [start, stop, step]):
             dtypes: list[DType] = [onnx.int64]
@@ -347,14 +319,13 @@ def arange(
 
 
 def eye(
-    dtype: DType[TY_ARRAY_BASE_co] | DTypeAlias,
+    dtype: DType[TY_ARRAY_BASE_co],
     n_rows: int,
     n_cols: int | None = None,
     /,
     *,
     k: int = 0,
 ) -> TY_ARRAY_BASE_co:
-    dtype = map_python_dtype(dtype)
     res = dtype.__ndx_eye__(n_rows, n_cols, k=k)
     if res is NotImplemented:
         raise TypeError(f"'eye' is not implemented for `{dtype}`")
@@ -362,10 +333,9 @@ def eye(
 
 
 def ones(
-    dtype: DType[TY_ARRAY_BASE_co] | DTypeAlias,
+    dtype: DType[TY_ARRAY_BASE_co],
     shape: tuple[int, ...] | onnx.TyArrayInt64,
 ) -> TY_ARRAY_BASE_co:
-    dtype = map_python_dtype(dtype)
     res = dtype.__ndx_ones__(shape)
     if res is NotImplemented:
         raise TypeError(f"'ones' is not implemented for `{dtype}`")
@@ -373,10 +343,9 @@ def ones(
 
 
 def zeros(
-    dtype: DType[TY_ARRAY_BASE_co] | DTypeAlias,
+    dtype: DType[TY_ARRAY_BASE_co],
     shape: tuple[int, ...] | onnx.TyArrayInt64,
 ) -> TY_ARRAY_BASE_co:
-    dtype = map_python_dtype(dtype)
     res = dtype.__ndx_zeros__(shape)
     if res is NotImplemented:
         raise TypeError(f"'zeros' is not implemented for `{dtype}`")

--- a/ndonnx/_typed_array/funcs.py
+++ b/ndonnx/_typed_array/funcs.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2025
+# Copyright (c) QuantCo 2023-2026
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
@@ -35,7 +35,7 @@ def map_python_dtype(dtype: DType | PyScalarType) -> DType: ...
 
 
 def map_python_dtype(dtype: DType | PyScalarType | None) -> DType | None:
-    """Intercept a ``dtype`` argument to support for python type aliases."""
+    """Intercept a ``dtype`` argument to support Python type aliases."""
     if dtype is None or isinstance(dtype, DType):
         return dtype
     if mapped_dtype := PYTHON_DTYPE_MAP.get(dtype):

--- a/ndonnx/_typed_array/funcs.py
+++ b/ndonnx/_typed_array/funcs.py
@@ -11,12 +11,36 @@ import numpy as np
 from spox import Var
 
 from ndonnx import DType, from_numpy_dtype
-from ndonnx.types import NestedSequence, PyScalar
+from ndonnx.types import NestedSequence, PyScalar, PyScalarType
 
 from . import TyArrayBase, datetime, masked_onnx, onnx, promote
 from ._utils import validate_op_result
 
 TY_ARRAY_BASE_co = TypeVar("TY_ARRAY_BASE_co", bound="TyArrayBase", covariant=True)
+
+PYTHON_DTYPE_MAP: dict[PyScalarType, DType] = {
+    bool: onnx.bool_,
+    int: onnx.int64,
+    float: onnx.float64,
+    str: onnx.utf8,
+}
+
+
+@overload
+def map_python_dtype(dtype: None) -> None: ...
+
+
+@overload
+def map_python_dtype(dtype: DType | PyScalarType) -> DType: ...
+
+
+def map_python_dtype(dtype: DType | PyScalarType | None) -> DType | None:
+    """Intercept a ``dtype`` argument to support for python type aliases."""
+    if dtype is None or isinstance(dtype, DType):
+        return dtype
+    if mapped_dtype := PYTHON_DTYPE_MAP.get(dtype):
+        return mapped_dtype
+    raise TypeError(f"unrecognized dtype argument: `{dtype}`")
 
 
 def _infer_sequence(
@@ -78,18 +102,19 @@ def astyarray(
 @overload
 def astyarray(
     val: PyScalar | np.ndarray | TyArrayBase | Var | NestedSequence,
-    dtype: None | DType = None,
+    dtype: None | PyScalarType | DType = None,
 ) -> TyArrayBase: ...
 
 
 def astyarray(
     val: PyScalar | np.ndarray | TyArrayBase | Var | NestedSequence,
-    dtype: None | DType[TY_ARRAY_BASE_co] = None,
+    dtype: None | PyScalarType | DType[TY_ARRAY_BASE_co] = None,
 ) -> TyArrayBase:
     """Conversion of values of various types into a built-in typed array.
 
     This function always copies.
     """
+    dtype = map_python_dtype(dtype)
     inferred_dtype = _infer_dtype(val) if dtype is None else dtype
     res = inferred_dtype.__ndx_create__(val)
     if res is NotImplemented:
@@ -293,11 +318,12 @@ def minimum(
 
 
 def arange(
-    dtype: DType[TY_ARRAY_BASE_co] | None,
+    dtype: DType[TY_ARRAY_BASE_co] | PyScalarType | None,
     start: int | float | TyArrayBase,
     stop: int | float | TyArrayBase,
     step: int | float | TyArrayBase = 1,
-) -> TyArrayBase:
+) -> TY_ARRAY_BASE_co:
+    dtype = map_python_dtype(dtype)
     if dtype is None:
         if all(isinstance(el, int) for el in [start, stop, step]):
             dtypes: list[DType] = [onnx.int64]
@@ -319,13 +345,14 @@ def arange(
 
 
 def eye(
-    dtype: DType[TY_ARRAY_BASE_co],
+    dtype: DType[TY_ARRAY_BASE_co] | PyScalarType,
     n_rows: int,
     n_cols: int | None = None,
     /,
     *,
     k: int = 0,
 ) -> TY_ARRAY_BASE_co:
+    dtype = map_python_dtype(dtype)
     res = dtype.__ndx_eye__(n_rows, n_cols, k=k)
     if res is NotImplemented:
         raise TypeError(f"'eye' is not implemented for `{dtype}`")
@@ -333,8 +360,10 @@ def eye(
 
 
 def ones(
-    dtype: DType[TY_ARRAY_BASE_co], shape: tuple[int, ...] | onnx.TyArrayInt64
+    dtype: DType[TY_ARRAY_BASE_co] | PyScalarType,
+    shape: tuple[int, ...] | onnx.TyArrayInt64,
 ) -> TY_ARRAY_BASE_co:
+    dtype = map_python_dtype(dtype)
     res = dtype.__ndx_ones__(shape)
     if res is NotImplemented:
         raise TypeError(f"'ones' is not implemented for `{dtype}`")
@@ -342,8 +371,10 @@ def ones(
 
 
 def zeros(
-    dtype: DType[TY_ARRAY_BASE_co], shape: tuple[int, ...] | onnx.TyArrayInt64
+    dtype: DType[TY_ARRAY_BASE_co] | PyScalarType,
+    shape: tuple[int, ...] | onnx.TyArrayInt64,
 ) -> TY_ARRAY_BASE_co:
+    dtype = map_python_dtype(dtype)
     res = dtype.__ndx_zeros__(shape)
     if res is NotImplemented:
         raise TypeError(f"'zeros' is not implemented for `{dtype}`")

--- a/ndonnx/_typed_array/funcs.py
+++ b/ndonnx/_typed_array/funcs.py
@@ -11,14 +11,14 @@ import numpy as np
 from spox import Var
 
 from ndonnx import DType, from_numpy_dtype
-from ndonnx.types import NestedSequence, PyScalar, PyScalarType
+from ndonnx.types import DTypeAlias, NestedSequence, PyScalar
 
 from . import TyArrayBase, datetime, masked_onnx, onnx, promote
 from ._utils import validate_op_result
 
 TY_ARRAY_BASE_co = TypeVar("TY_ARRAY_BASE_co", bound="TyArrayBase", covariant=True)
 
-PYTHON_DTYPE_MAP: dict[PyScalarType, DType] = {
+PYTHON_DTYPE_MAP: dict[DTypeAlias, DType] = {
     bool: onnx.bool_,
     "bool": onnx.bool_,
     int: onnx.int64,
@@ -33,10 +33,10 @@ def map_python_dtype(dtype: None) -> None: ...
 
 
 @overload
-def map_python_dtype(dtype: DType | PyScalarType) -> DType: ...
+def map_python_dtype(dtype: DType | DTypeAlias) -> DType: ...
 
 
-def map_python_dtype(dtype: DType | PyScalarType | None) -> DType | None:
+def map_python_dtype(dtype: DType | DTypeAlias | None) -> DType | None:
     """Intercept a ``dtype`` argument to support Python type aliases."""
     if dtype is None or isinstance(dtype, DType):
         return dtype
@@ -104,13 +104,13 @@ def astyarray(
 @overload
 def astyarray(
     val: PyScalar | np.ndarray | TyArrayBase | Var | NestedSequence,
-    dtype: None | PyScalarType | DType = None,
+    dtype: None | DTypeAlias | DType = None,
 ) -> TyArrayBase: ...
 
 
 def astyarray(
     val: PyScalar | np.ndarray | TyArrayBase | Var | NestedSequence,
-    dtype: None | PyScalarType | DType[TY_ARRAY_BASE_co] = None,
+    dtype: None | DTypeAlias | DType[TY_ARRAY_BASE_co] = None,
 ) -> TyArrayBase:
     """Conversion of values of various types into a built-in typed array.
 
@@ -320,7 +320,7 @@ def minimum(
 
 
 def arange(
-    dtype: DType[TY_ARRAY_BASE_co] | PyScalarType | None,
+    dtype: DType[TY_ARRAY_BASE_co] | DTypeAlias | None,
     start: int | float | TyArrayBase,
     stop: int | float | TyArrayBase,
     step: int | float | TyArrayBase = 1,
@@ -347,7 +347,7 @@ def arange(
 
 
 def eye(
-    dtype: DType[TY_ARRAY_BASE_co] | PyScalarType,
+    dtype: DType[TY_ARRAY_BASE_co] | DTypeAlias,
     n_rows: int,
     n_cols: int | None = None,
     /,
@@ -362,7 +362,7 @@ def eye(
 
 
 def ones(
-    dtype: DType[TY_ARRAY_BASE_co] | PyScalarType,
+    dtype: DType[TY_ARRAY_BASE_co] | DTypeAlias,
     shape: tuple[int, ...] | onnx.TyArrayInt64,
 ) -> TY_ARRAY_BASE_co:
     dtype = map_python_dtype(dtype)
@@ -373,7 +373,7 @@ def ones(
 
 
 def zeros(
-    dtype: DType[TY_ARRAY_BASE_co] | PyScalarType,
+    dtype: DType[TY_ARRAY_BASE_co] | DTypeAlias,
     shape: tuple[int, ...] | onnx.TyArrayInt64,
 ) -> TY_ARRAY_BASE_co:
     dtype = map_python_dtype(dtype)

--- a/ndonnx/types.py
+++ b/ndonnx/types.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2025
+# Copyright (c) QuantCo 2023-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 from __future__ import annotations

--- a/ndonnx/types.py
+++ b/ndonnx/types.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from types import EllipsisType
-from typing import TYPE_CHECKING, TypeAlias, Union
+from typing import TYPE_CHECKING, Literal, TypeAlias, Union
 
 if TYPE_CHECKING:
     from ._array import Array
@@ -26,7 +26,15 @@ SetitemKey: TypeAlias = Union[
 
 PyScalar = bool | int | float | str
 NestedSequence = Sequence["PyScalar | NestedSequence"]
-PyScalarType: TypeAlias = type[bool] | type[int] | type[float] | type[str] | str
+
+DTypeAlias: TypeAlias = (
+    type[bool]
+    | type[int]
+    | type[float]
+    | Literal["bool"]
+    | Literal["int"]
+    | Literal["float"]
+)
 
 
 __all__ = [

--- a/ndonnx/types.py
+++ b/ndonnx/types.py
@@ -26,7 +26,7 @@ SetitemKey: TypeAlias = Union[
 
 PyScalar = bool | int | float | str
 NestedSequence = Sequence["PyScalar | NestedSequence"]
-PyScalarType: TypeAlias = type[bool] | type[int] | type[float] | type[str]
+PyScalarType: TypeAlias = type[bool] | type[int] | type[float] | type[str] | str
 
 
 __all__ = [

--- a/ndonnx/types.py
+++ b/ndonnx/types.py
@@ -26,6 +26,7 @@ SetitemKey: TypeAlias = Union[
 
 PyScalar = bool | int | float | str
 NestedSequence = Sequence["PyScalar | NestedSequence"]
+PyScalarType: TypeAlias = type[bool] | type[int] | type[float] | type[str]
 
 
 __all__ = [

--- a/ndonnx/types.py
+++ b/ndonnx/types.py
@@ -28,14 +28,12 @@ PyScalar = bool | int | float | str
 NestedSequence = Sequence["PyScalar | NestedSequence"]
 
 DTypeAlias: TypeAlias = (
-    type[bool]
-    | type[int]
-    | type[float]
-    | Literal["bool"]
-    | Literal["int"]
-    | Literal["float"]
+    (type[bool] | type[int] | type[float])
+    | Literal["bool", "int", "float"]
+    | Literal["int8", "int16", "int32", "int64"]
+    | Literal["uint8", "uint16", "uint32", "uint64"]
+    | Literal["float16", "float32", "float64"]
 )
-
 
 __all__ = [
     "StrictShape",

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2025
+# Copyright (c) QuantCo 2023-2026
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -94,35 +94,3 @@ def test_time_dtype_creation_from_time_dtype(
         return npx.asarray(arr, dtype=new_dtype)
 
     np.testing.assert_array_equal(do(ndx).unwrap_numpy(), do(np))
-
-
-@pytest.mark.parametrize(
-    "dtype_alias, ndx_dtype",
-    [
-        (bool, ndx.bool),
-        ("bool", ndx.bool),
-        (int, ndx.int64),
-        ("int", ndx.int64),
-        (float, ndx.float64),
-        ("float", ndx.float64),
-    ],
-)
-def test_dtype_aliases(dtype_alias, ndx_dtype):
-    dos = [
-        lambda npx: npx.asarray(
-            [1, 0, 1], dtype=dtype_alias
-        ),  # creation with `dtype` argument
-        lambda npx: npx.asarray([1, 0, 1]).astype(
-            dtype_alias
-        ),  # calling `astype` after creation
-        lambda npx: npx.zeros((2,), dtype=dtype_alias),  # functions that accept `dtype`
-        lambda npx: npx.ones((2,), dtype=dtype_alias),
-        lambda npx: npx.full((2,), 1, dtype=dtype_alias),
-    ]
-    for do in dos:
-        assert do(ndx).dtype == ndx_dtype
-        np.testing.assert_equal(do(np), do(ndx).unwrap_numpy())
-
-    # Also test lazy arrays.
-    array = ndx.argument(shape=("N",), dtype=dtype_alias)
-    assert array.dtype == ndx_dtype

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -97,25 +97,32 @@ def test_time_dtype_creation_from_time_dtype(
 
 
 @pytest.mark.parametrize(
-    "python_type, ndx_dtype",
-    [(bool, ndx.bool), (int, ndx.int64), (float, ndx.float64), (str, ndx.utf8)],
+    "dtype_alias, ndx_dtype",
+    [
+        (bool, ndx.bool),
+        ("bool", ndx.bool),
+        (int, ndx.int64),
+        ("int", ndx.int64),
+        (float, ndx.float64),
+        ("float", ndx.float64),
+    ],
 )
-def test_python_dtype_aliases(python_type, ndx_dtype):
+def test_dtype_aliases(dtype_alias, ndx_dtype):
     dos = [
         lambda npx: npx.asarray(
-            [1, 0, 1], dtype=python_type
+            [1, 0, 1], dtype=dtype_alias
         ),  # creation with `dtype` argument
         lambda npx: npx.asarray([1, 0, 1]).astype(
-            python_type
+            dtype_alias
         ),  # calling `astype` after creation
-        lambda npx: npx.zeros((2,), dtype=python_type),  # functions that accept `dtype`
-        lambda npx: npx.ones((2,), dtype=python_type),
-        lambda npx: npx.full((2,), 1, dtype=python_type),
+        lambda npx: npx.zeros((2,), dtype=dtype_alias),  # functions that accept `dtype`
+        lambda npx: npx.ones((2,), dtype=dtype_alias),
+        lambda npx: npx.full((2,), 1, dtype=dtype_alias),
     ]
     for do in dos:
         assert do(ndx).dtype == ndx_dtype
         np.testing.assert_equal(do(np), do(ndx).unwrap_numpy())
 
     # Also test lazy arrays.
-    array = ndx.argument(shape=("N",), dtype=python_type)
+    array = ndx.argument(shape=("N",), dtype=dtype_alias)
     assert array.dtype == ndx_dtype

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -94,3 +94,28 @@ def test_time_dtype_creation_from_time_dtype(
         return npx.asarray(arr, dtype=new_dtype)
 
     np.testing.assert_array_equal(do(ndx).unwrap_numpy(), do(np))
+
+
+@pytest.mark.parametrize(
+    "python_type, ndx_dtype",
+    [(bool, ndx.bool), (int, ndx.int64), (float, ndx.float64), (str, ndx.utf8)],
+)
+def test_python_dtype_aliases(python_type, ndx_dtype):
+    dos = [
+        lambda npx: npx.asarray(
+            [1, 0, 1], dtype=python_type
+        ),  # creation with `dtype` argument
+        lambda npx: npx.asarray([1, 0, 1]).astype(
+            python_type
+        ),  # calling `astype` after creation
+        lambda npx: npx.zeros((2,), dtype=python_type),  # functions that accept `dtype`
+        lambda npx: npx.ones((2,), dtype=python_type),
+        lambda npx: npx.full((2,), 1, dtype=python_type),
+    ]
+    for do in dos:
+        assert do(ndx).dtype == ndx_dtype
+        np.testing.assert_equal(do(np), do(ndx).unwrap_numpy())
+
+    # Also test lazy arrays.
+    array = ndx.argument(shape=("N",), dtype=python_type)
+    assert array.dtype == ndx_dtype

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,0 +1,42 @@
+# Copyright (c) QuantCo 2023-2026
+# SPDX-License-Identifier: BSD-3-Clause
+
+import inspect
+
+import pytest
+
+import ndonnx as ndx
+
+NDONNX_EXCLUDE = [
+    "isdtype",
+    "to_nullable_dtype",
+]
+
+PUBLIC_INTERFACE = [
+    *[
+        (ndx, name)  # public functions of `ndonnx`
+        for name, _ in inspect.getmembers(ndx, predicate=inspect.isfunction)
+        if (
+            not name.startswith("_")
+            and callable(getattr(ndx, name))
+            and name not in NDONNX_EXCLUDE
+        )
+    ],
+    *[
+        (ndx.Array, name)  # public methods of `ndonnx.Array`
+        for name in dir(ndx.Array)
+        if not name.startswith("_") and callable(getattr(ndx.Array, name))
+    ],
+]
+
+
+@pytest.mark.parametrize("module, name", PUBLIC_INTERFACE)
+def test_dtype_and_aliases(module, name):
+    member = getattr(module, name)
+    sig = inspect.signature(member)
+    if dtype_param := sig.parameters.get("dtype"):
+        # If a public member has a `dtype` argument, then it must be annotated
+        # both with `DType` (i.e. native `ndonnx`) and `DTypeAlias` (others
+        # that map to a native `ndonnx` dtype).
+        assert "DType" in dtype_param.annotation
+        assert "DTypeAlias" in dtype_param.annotation

--- a/tests/test_refactor.py
+++ b/tests/test_refactor.py
@@ -1,4 +1,4 @@
-# Copyright (c) QuantCo 2023-2025
+# Copyright (c) QuantCo 2023-2026
 # SPDX-License-Identifier: BSD-3-Clause
 import json
 import operator


### PR DESCRIPTION
Adds the following aliases for dtypes (similar to how numpy does it) everywhere there is a `dtype` argument.
- `bool` --> `ndx.bool`
- `int` --> `ndx.int64`
- `float` --> `ndx.float64`
- String versions of the above

This allows for easier duck-typing, e.g.

```python
npx.asarray([1, 2], dtype=bool)  # now works for both npx == numpy (numpy.bool) and npx == ndonnx (ndonnx.bool)
```