### PR TITLE
fix(masked): take the mask into account in TyMaArray.is_constant

### DIFF
--- a/ndonnx/_typed_array/masked_onnx.py
+++ b/ndonnx/_typed_array/masked_onnx.py
@@ -411,7 +411,7 @@ class TyMaArray(TyMaArrayBase):
     def is_constant(self) -> bool:
         if self.mask is None:
             return self.data.is_constant
-        return self.data.is_constant and self.data.is_constant
+        return self.data.is_constant and self.mask.is_constant
 
     def _pass_through_same_type(self, fun_name: str, *args, **kwargs) -> Self:
         data = getattr(self.data, fun_name)(*args, **kwargs)

--- a/tests/test_masked.py
+++ b/tests/test_masked.py
@@ -313,3 +313,13 @@ def test_static_map_int64():
         [10, 0],
         candidate.unwrap_numpy().data[~candidate.unwrap_numpy().mask],  # type: ignore
     )
+
+
+def test_is_constant_on_partially_constant_array():
+    x = ndx.argument(shape=(3,), dtype=ndx.int64)
+    data = ndx.asarray(np.array([1, 2, 3], dtype=np.int64))
+    arr = ndx.extensions.make_nullable(data, x > 0)
+
+    assert arr._tyarray.data.is_constant
+    assert not arr._tyarray.mask.is_constant
+    assert not arr._tyarray.is_constant


### PR DESCRIPTION
### What

`TyMaArray.is_constant` ANDs `self.data.is_constant` with itself, so the mask is never consulted:

```python
@property
def is_constant(self) -> bool:
    if self.mask is None:
        return self.data.is_constant
    return self.data.is_constant and self.data.is_constant   # <- self.mask.is_constant
```

The `self.mask is None` early-return directly above shows the intent: past that point the mask is a real `onnx.TyArrayBool` and has to be checked too.

### Why it matters

`is_constant` is the predicate for "a propagated value is available" — `Array.unwrap_numpy()` documents that it raises `ValueError` when there isn't one. But `TyMaArray.unwrap_numpy()` unwraps **both** components:

```python
def unwrap_numpy(self) -> np.ndarray:
    return np.ma.masked_array(
        data=self.data.unwrap_numpy(),
        mask=np.ma.nomask if self.mask is None else self.mask.unwrap_numpy(),
    )
```

So a masked array with constant data and a lazy mask claims to be constant and then fails to unwrap.

### Reproduction

```python
import numpy as np
import ndonnx as ndx

x = ndx.argument(shape=(3,), dtype=ndx.int64)          # lazy
data = ndx.asarray(np.array([1, 2, 3], dtype=np.int64))  # constant
arr = ndx.extensions.make_nullable(data, x > 0)          # constant data, lazy mask

arr._tyarray.data.is_constant   # True
arr._tyarray.mask.is_constant   # False
arr._tyarray.is_constant        # True   <- wrong
arr.unwrap_numpy()              # ValueError: no propagated value available
```

On ndonnx 0.21.0:

```
data.is_constant = True
mask.is_constant = False
arr.is_constant  = True    <-- claims a propagated value exists
unwrap_numpy RAISED: ValueError no propagated value available
```

With the patch `arr.is_constant` is `False`, consistent with `unwrap_numpy()`.

### Not affected

* `mask is None` → still returns `self.data.is_constant` (guard untouched).
* Both constant → still `True`, and `unwrap_numpy()` still returns `[-- 2 3]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
