### PR TITLE
Add numerically sound implementations for log1p and expm1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Changelog
 =========
 
+0.22.0 (unreleased)
+-------------------
+
+**New feature**
+
+- Added support for :func:`ndonnx.log1p` and :func:`ndonnx.expm1`.
+
+
 0.21.0 (2026-08-07)
 -------------------
 

--- a/ndonnx/_funcs.py
+++ b/ndonnx/_funcs.py
@@ -449,15 +449,11 @@ def expand_dims(x: Array, /, *, axis: int = 0) -> Array:
 
 
 def expm1(x: Array, /) -> Array:
-    # Requires special operator to meet standards precision requirements
-    # TODO: Add upstream tracking issue
-    raise NotImplementedError
+    return Array._from_tyarray(x._tyarray.expm1())
 
 
 def log1p(x: Array, /) -> Array:
-    # Requires special operator to meet standards precision requirements
-    # TODO: Add upstream tracking issue
-    raise NotImplementedError
+    return Array._from_tyarray(x._tyarray.log1p())
 
 
 def conj(x: Array, /) -> Array:

--- a/ndonnx/_typed_array/masked_onnx.py
+++ b/ndonnx/_typed_array/masked_onnx.py
@@ -755,7 +755,9 @@ class TyMaArrayFloating(TyMaArrayNumber):
     cos = _make_unary_member_same_type("cos")  # type: ignore
     cosh = _make_unary_member_same_type("cosh")  # type: ignore
     exp = _make_unary_member_same_type("exp")  # type: ignore
+    expm1 = _make_unary_member_same_type("expm1")  # type: ignore
     log = _make_unary_member_same_type("log")  # type: ignore
+    log1p = _make_unary_member_same_type("log1p")  # type: ignore
     log2 = _make_unary_member_same_type("log2")  # type: ignore
     log10 = _make_unary_member_same_type("log10")  # type: ignore
     sin = _make_unary_member_same_type("sin")  # type: ignore

--- a/ndonnx/_typed_array/onnx.py
+++ b/ndonnx/_typed_array/onnx.py
@@ -1928,6 +1928,38 @@ class TyArrayFloating(TyArrayNumber):
             return safe_cast(TyArrayFloating, (x1.exp() + x2.exp()).log())
         return NotImplemented
 
+    @overload
+    def __add__(self: Self, other: Self | int | float) -> Self: ...
+    @overload
+    def __add__(self, other: TyArrayNumber | int | float) -> TyArrayNumber: ...
+    @overload
+    def __add__(self, other: TyArrayBase | PyScalar) -> TyArrayBase: ...
+    def __add__(self, other: TyArrayBase | PyScalar) -> TyArrayBase:
+        return super().__add__(other)
+
+    @overload
+    def __sub__(self: Self, other: Self | int | float) -> Self: ...
+    @overload
+    def __sub__(self, other: TyArrayNumber | int | float) -> TyArrayNumber: ...
+    @overload
+    def __sub__(self, other: TyArrayBase | PyScalar) -> TyArrayBase: ...
+    def __sub__(self, other: TyArrayBase | PyScalar) -> TyArrayBase:
+        return super().__sub__(other)
+
+    @overload
+    def __mul__(self: Self, other: Self | int | float) -> Self: ...
+    @overload
+    def __mul__(self, other: TyArrayBase | PyScalar) -> TyArrayBase: ...
+    def __mul__(self, other: TyArrayBase | PyScalar) -> TyArrayBase:
+        return super().__mul__(other)
+
+    @overload
+    def __truediv__(self: Self, other: Self | int | float) -> Self: ...
+    @overload
+    def __truediv__(self, other: TyArrayBase | PyScalar) -> TyArrayBase: ...
+    def __truediv__(self, other: TyArrayBase | PyScalar) -> TyArrayBase:
+        return super().__truediv__(other)
+
     def ceil(self) -> Self:
         return type(self)(op.ceil(self._var))
 
@@ -2073,6 +2105,14 @@ class TyArrayFloating(TyArrayNumber):
     def exp(self) -> Self:
         return type(self)(op.exp(self._var))
 
+    def expm1(self) -> Self:
+        # expm1(x) = (u - 1) * x / log(u) with u = exp(x); == x where u == 1.
+        # Analog of Goldberg's log1p (see below).
+        u = self.exp()
+        d = u - 1.0
+        tail = (d == -1.0) | u.isinf()
+        return where(u == 1.0, self, where(tail, d, d * self / u.log()))
+
     def log(self) -> Self:
         return type(self)(op.log(self._var))
 
@@ -2083,6 +2123,16 @@ class TyArrayFloating(TyArrayNumber):
     def log10(self) -> Self:
         res = self.log() / float(np.log(10))
         return safe_cast(type(self), res)
+
+    def log1p(self) -> Self:
+        # log1p(x) = log(u) * x / (u - 1) with u = 1 + x; == x where u == 1.
+        # Goldberg, "What Every Computer Scientist Should Know About
+        # Floating-Point Arithmetic", Theorem 4:
+        # https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
+        u = self + 1.0
+        d = u - 1.0
+        short_circuit = (u == 1.0) | (self.isinf() & (self > 0.0))
+        return where(short_circuit, self, u.log() * (self / d))
 
     def sin(self) -> Self:
         return type(self)(op.sin(self._var))

--- a/skips.txt
+++ b/skips.txt
@@ -37,15 +37,11 @@ array_api_tests/test_has_names.py::test_has_names[elementwise-imag]
 array_api_tests/test_has_names.py::test_has_names[elementwise-real]
 array_api_tests/test_has_names.py::test_has_names[elementwise-signbit]
 array_api_tests/test_has_names.py::test_has_names[elementwise-atan2]
-array_api_tests/test_has_names.py::test_has_names[elementwise-expm1]
-array_api_tests/test_has_names.py::test_has_names[elementwise-log1p]
 array_api_tests/test_has_names.py::test_has_names[elementwise-nextafter]
 
 array_api_tests/test_operators_and_elementwise_functions.py::test_atan2
 array_api_tests/test_operators_and_elementwise_functions.py::test_copysign
-array_api_tests/test_operators_and_elementwise_functions.py::test_expm1
 array_api_tests/test_operators_and_elementwise_functions.py::test_hypot
-array_api_tests/test_operators_and_elementwise_functions.py::test_log1p
 array_api_tests/test_operators_and_elementwise_functions.py::test_signbit
 array_api_tests/test_operators_and_elementwise_functions.py::test_nextafter
 
@@ -85,6 +81,10 @@ array_api_tests/test_special_cases.py::test_binary[nextafter(x1_i is NaN or x2_i
 array_api_tests/test_special_cases.py::test_binary[nextafter(x1_i is -0 and x2_i is +0) -> +0]
 array_api_tests/test_special_cases.py::test_binary[nextafter(x1_i is +0 and x2_i is -0) -> -0]
 
+# log1p and expm1 fail to propagate -0 because onnxruntime's where fails to do so
+array_api_tests/test_special_cases.py::test_unary[log1p(x_i is -0) -> -0]
+array_api_tests/test_special_cases.py::test_unary[expm1(x_i is -0) -> -0]
+
 array_api_tests/test_special_cases.py::test_unary[acos(x_i < -1) -> NaN]
 array_api_tests/test_special_cases.py::test_unary[acos(x_i > 1) -> NaN]
 array_api_tests/test_special_cases.py::test_unary[acosh(x_i < 1) -> NaN]
@@ -92,17 +92,6 @@ array_api_tests/test_special_cases.py::test_unary[asin(x_i < -1) -> NaN]
 array_api_tests/test_special_cases.py::test_unary[asin(x_i > 1) -> NaN]
 array_api_tests/test_special_cases.py::test_unary[atanh(x_i < -1) -> NaN]
 array_api_tests/test_special_cases.py::test_unary[atanh(x_i > 1) -> NaN]
-array_api_tests/test_special_cases.py::test_unary[expm1(x_i is +0) -> +0]
-array_api_tests/test_special_cases.py::test_unary[expm1(x_i is +infinity) -> +infinity]
-array_api_tests/test_special_cases.py::test_unary[expm1(x_i is -0) -> -0]
-array_api_tests/test_special_cases.py::test_unary[expm1(x_i is -infinity) -> -1]
-array_api_tests/test_special_cases.py::test_unary[expm1(x_i is NaN) -> NaN]
-array_api_tests/test_special_cases.py::test_unary[log1p(x_i < -1) -> NaN]
-array_api_tests/test_special_cases.py::test_unary[log1p(x_i is +0) -> +0]
-array_api_tests/test_special_cases.py::test_unary[log1p(x_i is +infinity) -> +infinity]
-array_api_tests/test_special_cases.py::test_unary[log1p(x_i is -0) -> -0]
-array_api_tests/test_special_cases.py::test_unary[log1p(x_i is -1) -> -infinity]
-array_api_tests/test_special_cases.py::test_unary[log1p(x_i is NaN) -> NaN]
 array_api_tests/test_special_cases.py::test_unary[signbit(isfinite(x_i) and x_i < 0) -> True]
 array_api_tests/test_special_cases.py::test_unary[signbit(isfinite(x_i) and x_i > 0) -> False]
 array_api_tests/test_special_cases.py::test_unary[signbit(x_i is +0) -> False]


### PR DESCRIPTION
We recently ran into the lack of these functions when working on some internal documentation. The implementation is tested by the upstream array-api test suite. It turns out that onnxruntime's `Where`-operator apparently doesn't correctly propagate `-0.0`, which is why those special cases are still skipped.

FYI @fjetter 